### PR TITLE
feat: alert spine + ci-doctor

### DIFF
--- a/.github/workflows/ci-doctor.yml
+++ b/.github/workflows/ci-doctor.yml
@@ -1,0 +1,47 @@
+name: ci-doctor
+on:
+  workflow_run:
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  diagnose:
+    # Only run on failure; never recurse on ci-doctor's own failures.
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'failure'
+          && github.event.workflow_run.name != 'ci-doctor' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install ci-doctor deps
+        working-directory: tools/ci-doctor
+        run: npm install --no-audit --no-fund
+
+      - name: Install psql client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client
+
+      - name: Run unit tests
+        working-directory: tools/ci-doctor
+        run: npm test
+
+      - name: Run ci-doctor
+        working-directory: tools/ci-doctor
+        env:
+          GITHUB_TOKEN:      ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DATABASE_URL:      ${{ secrets.DATABASE_URL }}
+          RUN_ID:            ${{ github.event.workflow_run.id }}
+        run: npx tsx index.ts

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -1,0 +1,47 @@
+name: hive-digest
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # every 15 minutes — tier 1 (real-time)
+    - cron: '0 13 * * *'     # daily 1pm UTC (8am St Louis) — tier 2
+    - cron: '0 13 * * 1'     # Monday 1pm UTC (8am St Louis) — tier 3
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'tier1 | tier2 | tier3'
+        required: true
+        default: 'tier1'
+
+permissions:
+  contents: read
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: pip install --quiet psycopg2-binary
+
+      - name: Resolve mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "mode=${{ inputs.mode }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.schedule }}" = "0 13 * * 1" ]; then
+            echo "mode=tier3" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.schedule }}" = "0 13 * * *" ]; then
+            echo "mode=tier2" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=tier1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Send digest
+        env:
+          DATABASE_URL:   ${{ secrets.DATABASE_URL }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+        run: python scripts/digest.py ${{ steps.mode.outputs.mode }}

--- a/.github/workflows/run-migration.yml
+++ b/.github/workflows/run-migration.yml
@@ -1,0 +1,49 @@
+name: run-migration
+on:
+  workflow_dispatch:
+    inputs:
+      migration:
+        description: 'Migration file under migrations/ to apply'
+        required: true
+        default: '001_hive_alerts.sql'
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install psql client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client
+
+      - name: Apply migration
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DATABASE_URL:-}" ]; then
+            echo "DATABASE_URL secret is not set" >&2
+            exit 1
+          fi
+          FILE="migrations/${{ inputs.migration }}"
+          if [ ! -f "$FILE" ]; then
+            echo "Migration file not found: $FILE" >&2
+            exit 1
+          fi
+          echo "Applying $FILE"
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$FILE"
+
+      - name: Verify hive_alerts exists
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          echo "Row count for hive_alerts:"
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "SELECT count(*) AS hive_alerts_rows FROM hive_alerts;"
+          echo "Schema for hive_alerts:"
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "\d hive_alerts"

--- a/migrations/001_hive_alerts.sql
+++ b/migrations/001_hive_alerts.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS hive_alerts (
+  id uuid primary key default gen_random_uuid(),
+  tier int not null check (tier in (1,2,3)),
+  agent text not null,
+  subject text not null,
+  body text not null,
+  action_required boolean default false,
+  action_url text,
+  sent boolean default false,
+  created_at timestamptz default now()
+);
+CREATE INDEX IF NOT EXISTS idx_alerts_unsent ON hive_alerts(sent, tier, created_at);

--- a/scripts/digest.py
+++ b/scripts/digest.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""HIVE alert digest agent.
+
+Reads pending rows from `hive_alerts` and dispatches them via Resend.
+
+Modes:
+  tier1  - send each unsent tier-1 row as its own email (real-time)
+  tier2  - compile all unsent tier-2 rows from last 24h into one daily digest
+  tier3  - compile all unsent tier-3 rows from last 7 days into one weekly digest
+
+Marks rows `sent = true` only after Resend confirms delivery.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+SENDER = "hive@hive.baby"
+RECIPIENT = "saggarsonny@gmail.com"
+RESEND_URL = "https://api.resend.com/emails"
+
+
+def send_email(subject: str, body: str, api_key: str) -> bool:
+    payload = json.dumps({
+        "from":    SENDER,
+        "to":      [RECIPIENT],
+        "subject": subject,
+        "text":    body,
+    }).encode()
+    req = urllib.request.Request(
+        RESEND_URL,
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type":  "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            print(f"  Email sent (HTTP {resp.status}): {subject}")
+            return True
+    except urllib.error.HTTPError as e:
+        print(f"  Email error {e.code}: {e.read().decode(errors='replace')[:300]}")
+        return False
+    except urllib.error.URLError as e:
+        print(f"  Email transport error: {e}")
+        return False
+
+
+def fmt_alert(row: dict) -> str:
+    parts = [f"[{row['agent']}] {row['subject']}", "", row['body']]
+    if row.get('action_url'):
+        parts += ["", f"Action: {row['action_url']}"]
+    parts.append(f"At: {row['created_at'].isoformat()}")
+    return "\n".join(parts)
+
+
+def mark_sent(conn, ids: list) -> None:
+    if not ids:
+        return
+    with conn.cursor() as cur:
+        cur.execute("UPDATE hive_alerts SET sent = true WHERE id = ANY(%s)", (ids,))
+    conn.commit()
+
+
+def run_tier1(conn, api_key: str) -> None:
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT id, tier, agent, subject, body, action_url, created_at
+              FROM hive_alerts
+             WHERE sent = false AND tier = 1
+             ORDER BY created_at ASC
+             LIMIT 100
+            """
+        )
+        rows = cur.fetchall()
+    print(f"Tier 1 unsent: {len(rows)}")
+    for row in rows:
+        ok = send_email(row["subject"], fmt_alert(row), api_key)
+        if ok:
+            mark_sent(conn, [row["id"]])
+
+
+def run_digest(conn, tier: int, interval: str, label: str, api_key: str) -> None:
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            f"""
+            SELECT id, tier, agent, subject, body, action_url, created_at
+              FROM hive_alerts
+             WHERE sent = false
+               AND tier = %s
+               AND created_at > now() - interval %s
+             ORDER BY created_at ASC
+            """,
+            (tier, interval),
+        )
+        rows = cur.fetchall()
+    print(f"Tier {tier} unsent ({interval}): {len(rows)}")
+    if not rows:
+        return
+    today = datetime.now(timezone.utc).date().isoformat()
+    subject = f"HIVE {label} — {today}"
+    sections = [fmt_alert(r) for r in rows]
+    body = (
+        f"{len(rows)} alert(s) over the last {interval}.\n\n"
+        + ("\n\n---\n\n".join(sections))
+    )
+    ok = send_email(subject, body, api_key)
+    if ok:
+        mark_sent(conn, [r["id"] for r in rows])
+
+
+def main() -> int:
+    mode = (sys.argv[1] if len(sys.argv) > 1 else "tier1").strip()
+    db_url = os.environ.get("DATABASE_URL")
+    api_key = os.environ.get("RESEND_API_KEY")
+    if not db_url:
+        print("DATABASE_URL not set", file=sys.stderr)
+        return 1
+    if not api_key:
+        print("RESEND_API_KEY not set", file=sys.stderr)
+        return 1
+
+    conn = psycopg2.connect(db_url)
+    try:
+        if mode == "tier1":
+            run_tier1(conn, api_key)
+        elif mode == "tier2":
+            run_digest(conn, 2, "24 hours", "DAILY", api_key)
+        elif mode == "tier3":
+            run_digest(conn, 3, "7 days", "WEEKLY", api_key)
+        else:
+            print(f"Unknown mode: {mode}", file=sys.stderr)
+            return 1
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci-doctor/config.yml
+++ b/tools/ci-doctor/config.yml
@@ -1,0 +1,6 @@
+monitored_workflows: all
+auto_fix_enabled: true
+auto_fix_whitelist:
+  - .github/workflows/*.yml
+alert_on_unknown: true
+max_auto_prs_per_day: 5

--- a/tools/ci-doctor/index.ts
+++ b/tools/ci-doctor/index.ts
@@ -1,0 +1,523 @@
+/**
+ * ci-doctor — auto-diagnose failed GitHub Actions workflows for hivebaby.
+ *
+ * Reads a failing run, classifies the failure against a fixed ruleset,
+ * writes a tier-1 row into hive_alerts, and (when safe) opens a draft PR
+ * with a workflow-file-only patch. Never auto-merges. Never edits app code.
+ */
+
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const WORKFLOW_WHITELIST = /^\.github\/workflows\/[A-Za-z0-9._-]+\.ya?ml$/;
+
+export interface Diagnosis {
+  rule:
+    | 'missing_dep'
+    | 'missing_secret'
+    | 'missing_file'
+    | 'deprecated_action'
+    | 'script_exit'
+    | 'timeout'
+    | 'missing_env_var'
+    | 'unknown';
+  cause: string;
+  evidence: string;
+  suggestedFix: string;
+  autoFixable: boolean;
+}
+
+export interface FailureContext {
+  runId: number;
+  runUrl: string;
+  workflowName: string;
+  workflowPath: string;
+  jobName: string;
+  stepName: string;
+  log: string;
+  headBranch: string;
+  defaultBranch: string;
+}
+
+export interface CiDoctorConfig {
+  monitored_workflows: string;
+  auto_fix_enabled: boolean;
+  auto_fix_whitelist: string[];
+  alert_on_unknown: boolean;
+  max_auto_prs_per_day: number;
+}
+
+// ---------- GitHub API helpers ----------
+
+function ghHeaders(): Record<string, string> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN is required');
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'ci-doctor/0.1',
+  };
+}
+
+async function ghJson(path: string, init: RequestInit = {}): Promise<any> {
+  const res = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: { ...ghHeaders(), 'Content-Type': 'application/json', ...(init.headers || {}) },
+  });
+  if (!res.ok) {
+    const t = await res.text();
+    throw new Error(`GitHub API ${res.status} on ${path}: ${t.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+async function ghText(path: string): Promise<string> {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: ghHeaders(),
+    redirect: 'follow',
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status} on ${path}`);
+  }
+  return res.text();
+}
+
+// ---------- fetchFailure ----------
+
+export async function fetchFailure(runId: number): Promise<FailureContext> {
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo) throw new Error('GITHUB_REPOSITORY is required');
+
+  const run = await ghJson(`/repos/${repo}/actions/runs/${runId}`);
+  const jobsResp = await ghJson(`/repos/${repo}/actions/runs/${runId}/jobs?per_page=100`);
+  const jobs: any[] = jobsResp.jobs || [];
+  const failedJob = jobs.find((j) => j.conclusion === 'failure');
+  if (!failedJob) {
+    throw new Error(`No failed job found in run ${runId}`);
+  }
+  const failedStep = (failedJob.steps || []).find((s: any) => s.conclusion === 'failure');
+
+  let logTail = '';
+  try {
+    const fullLog = await ghText(`/repos/${repo}/actions/jobs/${failedJob.id}/logs`);
+    const lines = fullLog.split('\n');
+    logTail = lines.slice(-100).join('\n');
+  } catch (e) {
+    logTail = `[ci-doctor] could not fetch job log: ${(e as Error).message}`;
+  }
+
+  return {
+    runId,
+    runUrl: run.html_url,
+    workflowName: run.name || run.path || 'unknown',
+    workflowPath: run.path || '',
+    jobName: failedJob.name,
+    stepName: failedStep?.name || '(unknown step)',
+    log: logTail,
+    headBranch: run.head_branch || 'main',
+    defaultBranch: run.repository?.default_branch || 'main',
+  };
+}
+
+// ---------- diagnose ----------
+
+const ENV_VAR_RE =
+  /\b(ANTHROPIC[A-Z0-9_]*|STRIPE[A-Z0-9_]*|CLERK[A-Z0-9_]*|CF_[A-Z0-9_]+|VERCEL[A-Z0-9_]*|DATABASE_URL)\b/;
+
+export function diagnose(log: string): Diagnosis {
+  const lines = log.split('\n');
+
+  // Rule 2: missing secret
+  const secretA = log.match(/Error:\s*Input required and not supplied(?::\s*([A-Za-z0-9_-]+))?/);
+  const secretB = log.match(/Error:\s*secret\s+([A-Za-z0-9_-]+)\s+not found/i);
+  if (secretA || secretB) {
+    const name = (secretB && secretB[1]) || (secretA && secretA[1]) || 'unknown';
+    const evidence =
+      lines.filter((l) => /Input required and not supplied|secret .* not found/i.test(l)).join('\n') ||
+      (secretA?.[0] || secretB?.[0] || '');
+    return {
+      rule: 'missing_secret',
+      cause: `missing secret: ${name}`,
+      evidence,
+      suggestedFix:
+        `Add secret \`${name}\` in repo Settings → Secrets and variables → Actions, ` +
+        `then re-run the failed job.`,
+      autoFixable: false,
+    };
+  }
+
+  // Rule 7: env var missing — runs early because exit-1 from rule 5 might also
+  // mention these vars; prefer the env-var diagnosis when present.
+  const envHit = lines.find((l) => ENV_VAR_RE.test(l) && /missing|undefined|not\s+set|not\s+defined|not\s+configured|required/i.test(l));
+  if (envHit) {
+    const m = envHit.match(ENV_VAR_RE);
+    const name = m ? m[1] : 'unknown';
+    return {
+      rule: 'missing_env_var',
+      cause: `missing env var: ${name}`,
+      evidence: envHit.trim(),
+      suggestedFix:
+        `Set \`${name}\` in this workflow's \`env:\` block or add it as a repo secret ` +
+        `and reference it via \`${name}: \${{ secrets.${name} }}\`.`,
+      autoFixable: false,
+    };
+  }
+
+  // Rule 1: missing dependency
+  const npm404 = log.match(/npm ERR! 404[^\n]*?(?:'?([@a-zA-Z0-9._/-]+)'?)?/);
+  const cantFind = log.match(/Cannot find module ['"]([^'"]+)['"]/);
+  if (npm404 || cantFind) {
+    const mod = (cantFind && cantFind[1]) || (npm404 && npm404[1]) || 'unknown';
+    const evidence = lines
+      .filter((l) => /npm ERR!|Cannot find module/.test(l))
+      .slice(0, 8)
+      .join('\n');
+    return {
+      rule: 'missing_dep',
+      cause: `missing dependency${mod !== 'unknown' ? `: ${mod}` : ''}`,
+      evidence,
+      suggestedFix:
+        `If \`${mod}\` is a real package, add it to package.json (\`npm i ${mod}\`). ` +
+        `If the workflow runs \`npm install\` against a missing lockfile, switch the install ` +
+        `step to \`npm ci\` and ensure package-lock.json is committed.`,
+      autoFixable: true,
+    };
+  }
+
+  // Rule 4: deprecated action
+  const deprec =
+    log.match(/(actions\/[a-z0-9-]+)@v(\d+)[^\n]*?(?:is deprecated|deprecation warning)/i) ||
+    log.match(/The `?(actions\/[a-z0-9-]+)@v(\d+)`?[^\n]*?(?:deprecated)/i);
+  if (deprec) {
+    const action = deprec[1];
+    const oldV = parseInt(deprec[2], 10);
+    return {
+      rule: 'deprecated_action',
+      cause: `deprecated action: ${action}@v${oldV}`,
+      evidence: deprec[0],
+      suggestedFix: `Bump ${action} from @v${oldV} to @v${oldV + 1} (current major).`,
+      autoFixable: true,
+    };
+  }
+
+  // Rule 3: missing file / wrong working-directory
+  const noFile = log.match(/No such file or directory[^\n]*?([./][^\s'"`]+)/);
+  if (noFile) {
+    return {
+      rule: 'missing_file',
+      cause: `missing file or wrong working-directory: ${noFile[1]}`,
+      evidence: noFile[0],
+      suggestedFix:
+        `Confirm the path \`${noFile[1]}\` exists in the repo. If the step uses ` +
+        `\`working-directory:\`, verify it points at the correct subdirectory.`,
+      autoFixable: true,
+    };
+  }
+
+  // Rule 6: timeout / canceled
+  if (/Timeout|The operation was canceled/i.test(log)) {
+    const ev = lines.filter((l) => /timeout|canceled/i.test(l)).slice(0, 5).join('\n');
+    return {
+      rule: 'timeout',
+      cause: 'timeout / job canceled',
+      evidence: ev,
+      suggestedFix:
+        `Increase \`timeout-minutes\`, split the job into smaller steps, ` +
+        `or check for runner capacity issues. Re-run when traffic settles.`,
+      autoFixable: false,
+    };
+  }
+
+  // Rule 5: bare exit 1..9
+  const exitRe = /\bexit\s+code\s+([1-9])\b|\bexit\s+([1-9])\b/;
+  const exitIdx = lines.findIndex((l) => exitRe.test(l));
+  if (exitIdx >= 0) {
+    const m = lines[exitIdx].match(exitRe);
+    const code = (m && (m[1] || m[2])) || '?';
+    const ctx = lines.slice(Math.max(0, exitIdx - 20), exitIdx + 1).join('\n');
+    return {
+      rule: 'script_exit',
+      cause: `script-level guard tripped (exit ${code})`,
+      evidence: ctx,
+      suggestedFix:
+        `A script-level check fired. Review the 20 lines preceding the exit ` +
+        `(included in evidence) — that's where the assertion lives.`,
+      autoFixable: false,
+    };
+  }
+
+  // No match
+  return {
+    rule: 'unknown',
+    cause: 'unknown failure',
+    evidence: lines.slice(0, 80).join('\n'),
+    suggestedFix:
+      `No rule matched. Read the run log directly. ` +
+      `If this is a recurring class of failure, add a rule to ci-doctor's diagnose().`,
+    autoFixable: false,
+  };
+}
+
+// ---------- writeAlert ----------
+
+function dollarQuote(s: string): string {
+  let tag = 'hd';
+  while (s.includes(`$${tag}$`)) tag = 'hd' + Math.random().toString(36).slice(2, 8);
+  return `$${tag}$${s}$${tag}$`;
+}
+
+export function writeAlert(diagnosis: Diagnosis, ctx: FailureContext, prUrl?: string): void {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    console.log('[ci-doctor] DATABASE_URL not set — skipping hive_alerts insert.');
+    return;
+  }
+
+  const subject = `🔧 CI failed: ${ctx.workflowName} — ${diagnosis.cause}`;
+  const bodyLines = [
+    `Workflow:     ${ctx.workflowName}`,
+    `Workflow file:${ctx.workflowPath}`,
+    `Job:          ${ctx.jobName}`,
+    `Step:         ${ctx.stepName}`,
+    ``,
+    `Cause:        ${diagnosis.cause}`,
+    `Rule:         ${diagnosis.rule}`,
+    `Auto-fixable: ${diagnosis.autoFixable}`,
+    ``,
+    `Evidence:`,
+    diagnosis.evidence,
+    ``,
+    `Suggested fix:`,
+    diagnosis.suggestedFix,
+    ``,
+    `Failing run: ${ctx.runUrl}`,
+  ];
+  if (prUrl) bodyLines.push(`Auto-fix PR: ${prUrl}`);
+  const body = bodyLines.join('\n');
+  const actionUrl = prUrl || ctx.runUrl;
+
+  const sql =
+    `INSERT INTO hive_alerts (tier, agent, subject, body, action_required, action_url) ` +
+    `VALUES (1, 'ci-doctor', ${dollarQuote(subject)}, ${dollarQuote(body)}, true, ${dollarQuote(actionUrl)});`;
+
+  execFileSync('psql', [dbUrl, '-v', 'ON_ERROR_STOP=1', '-c', sql], { stdio: 'inherit' });
+  console.log('[ci-doctor] alert written to hive_alerts.');
+}
+
+// ---------- maybeOpenPR ----------
+
+function assertWhitelisted(file: string): void {
+  if (!WORKFLOW_WHITELIST.test(file)) {
+    throw new Error(`ci-doctor: refusing to write outside whitelist: ${file}`);
+  }
+}
+
+function computePatch(diagnosis: Diagnosis, wfPath: string): Record<string, string> | null {
+  if (!wfPath || !existsSync(wfPath)) return null;
+  assertWhitelisted(wfPath);
+
+  if (diagnosis.rule === 'deprecated_action') {
+    const m = diagnosis.cause.match(/deprecated action:\s+(actions\/[a-z0-9-]+)@v(\d+)/);
+    if (!m) return null;
+    const action = m[1];
+    const oldV = parseInt(m[2], 10);
+    const newV = oldV + 1;
+    const original = readFileSync(wfPath, 'utf8');
+    const re = new RegExp(`(${action.replace(/\//g, '\\/')})@v${oldV}\\b`, 'g');
+    const updated = original.replace(re, `$1@v${newV}`);
+    if (updated === original) return null;
+    return { [wfPath]: updated };
+  }
+
+  // Other rules: alert-only for now (no safe patch we can generate from logs alone).
+  return null;
+}
+
+async function countPRsToday(repo: string): Promise<number> {
+  const today = new Date().toISOString().slice(0, 10);
+  const q = encodeURIComponent(`repo:${repo} is:pr head:ci-doctor/ created:>=${today}T00:00:00Z`);
+  const res = await ghJson(`/search/issues?q=${q}`);
+  return res.total_count || 0;
+}
+
+export async function maybeOpenPR(
+  diagnosis: Diagnosis,
+  ctx: FailureContext,
+  cfg: CiDoctorConfig,
+): Promise<string | null> {
+  if (!cfg.auto_fix_enabled) {
+    console.log('[ci-doctor] auto_fix_enabled = false, skipping PR.');
+    return null;
+  }
+  if (!diagnosis.autoFixable) return null;
+
+  const repo = process.env.GITHUB_REPOSITORY!;
+  const cap = cfg.max_auto_prs_per_day;
+  const used = await countPRsToday(repo);
+  if (used >= cap) {
+    console.log(`[ci-doctor] daily PR cap reached (${used}/${cap}) — skipping PR.`);
+    return null;
+  }
+
+  const patch = computePatch(diagnosis, ctx.workflowPath);
+  if (!patch) {
+    console.log('[ci-doctor] no clean patch available — alert only.');
+    return null;
+  }
+
+  const branch = `ci-doctor/fix-${ctx.runId}`;
+  const base = ctx.defaultBranch || 'main';
+
+  for (const file of Object.keys(patch)) assertWhitelisted(file);
+
+  execSync(`git config user.name "ci-doctor"`);
+  execSync(`git config user.email "ci-doctor@hive.baby"`);
+  execSync(`git fetch origin ${base}`);
+  execSync(`git checkout -B ${branch} origin/${base}`);
+
+  for (const [file, content] of Object.entries(patch)) {
+    writeFileSync(file, content);
+  }
+
+  // Final guard: refuse if any non-whitelisted file is staged.
+  const status = execSync('git status --porcelain').toString().trim();
+  for (const line of status.split('\n').filter(Boolean)) {
+    const file = line.slice(3);
+    assertWhitelisted(file);
+  }
+
+  execSync(`git add ${Object.keys(patch).map((f) => `'${f}'`).join(' ')}`);
+  execSync(`git commit -m ${JSON.stringify(`ci-doctor: ${diagnosis.cause}`)}`);
+  execSync(`git push -u origin ${branch}`, { stdio: 'inherit' });
+
+  const diff = execSync(`git diff origin/${base}..${branch}`).toString().slice(0, 4000);
+  const prBody = [
+    `## ci-doctor auto-fix`,
+    ``,
+    `**Failing run:** ${ctx.runUrl}`,
+    `**Workflow:** \`${ctx.workflowPath}\``,
+    `**Job → Step:** ${ctx.jobName} → ${ctx.stepName}`,
+    `**Cause:** ${diagnosis.cause}`,
+    `**Rule:** \`${diagnosis.rule}\``,
+    ``,
+    `### Evidence`,
+    '```',
+    diagnosis.evidence,
+    '```',
+    ``,
+    `### Suggested fix`,
+    diagnosis.suggestedFix,
+    ``,
+    `### Diff`,
+    '```diff',
+    diff,
+    '```',
+    ``,
+    `### Rollback`,
+    '```bash',
+    `git revert -m 1 <merge-commit-sha>`,
+    `# or simply close this PR — nothing is auto-merged.`,
+    '```',
+    ``,
+    `_ci-doctor never auto-merges. Review and merge manually._`,
+  ].join('\n');
+
+  const pr = await ghJson(`/repos/${repo}/pulls`, {
+    method: 'POST',
+    body: JSON.stringify({
+      title: `🔧 ci-doctor: auto-fix for ${ctx.workflowName}`,
+      head: branch,
+      base,
+      body: prBody,
+      draft: true,
+    }),
+  });
+  console.log(`[ci-doctor] PR opened: ${pr.html_url}`);
+  return pr.html_url as string;
+}
+
+// ---------- config loader ----------
+
+export function loadConfig(): CiDoctorConfig {
+  const cfg: CiDoctorConfig = {
+    monitored_workflows: 'all',
+    auto_fix_enabled: true,
+    auto_fix_whitelist: [],
+    alert_on_unknown: true,
+    max_auto_prs_per_day: 5,
+  };
+  const file = join(__dirname, 'config.yml');
+  if (!existsSync(file)) return cfg;
+  const raw = readFileSync(file, 'utf8');
+  let lastListKey: keyof CiDoctorConfig | null = null;
+  for (const rawLine of raw.split('\n')) {
+    const line = rawLine.replace(/#.*$/, '');
+    if (!line.trim()) continue;
+    const listMatch = line.match(/^\s+-\s+(.+?)\s*$/);
+    if (listMatch && lastListKey) {
+      (cfg[lastListKey] as string[]).push(listMatch[1].replace(/^['"]|['"]$/g, ''));
+      continue;
+    }
+    const kv = line.match(/^([a-z_]+):\s*(.*)$/);
+    if (kv) {
+      const k = kv[1] as keyof CiDoctorConfig;
+      const v = kv[2].trim();
+      if (v === '') {
+        (cfg as any)[k] = [];
+        lastListKey = k;
+      } else if (v === 'true') (cfg as any)[k] = true;
+      else if (v === 'false') (cfg as any)[k] = false;
+      else if (/^\d+$/.test(v)) (cfg as any)[k] = parseInt(v, 10);
+      else {
+        (cfg as any)[k] = v.replace(/^['"]|['"]$/g, '');
+        lastListKey = null;
+      }
+    }
+  }
+  return cfg;
+}
+
+// ---------- entry point ----------
+
+async function main(): Promise<void> {
+  const runId = parseInt(process.env.RUN_ID || '0', 10);
+  if (!runId) throw new Error('RUN_ID env var is required');
+
+  const cfg = loadConfig();
+  const ctx = await fetchFailure(runId);
+  console.log(
+    `[ci-doctor] inspecting run ${runId} — workflow="${ctx.workflowName}" job="${ctx.jobName}" step="${ctx.stepName}"`,
+  );
+
+  const diag = diagnose(ctx.log);
+  console.log(`[ci-doctor] diagnosis: rule=${diag.rule} autoFixable=${diag.autoFixable}`);
+  console.log(`[ci-doctor] cause: ${diag.cause}`);
+
+  if (diag.rule === 'unknown' && !cfg.alert_on_unknown) {
+    console.log('[ci-doctor] unknown failure and alert_on_unknown=false; skipping.');
+    return;
+  }
+
+  let prUrl: string | null = null;
+  try {
+    prUrl = await maybeOpenPR(diag, ctx, cfg);
+  } catch (e) {
+    console.error('[ci-doctor] maybeOpenPR failed:', (e as Error).message);
+  }
+
+  writeAlert(diag, ctx, prUrl || undefined);
+}
+
+const isMain =
+  process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  main().catch((e) => {
+    console.error('[ci-doctor] fatal:', e);
+    process.exit(1);
+  });
+}

--- a/tools/ci-doctor/package-lock.json
+++ b/tools/ci-doctor/package-lock.json
@@ -1,0 +1,590 @@
+{
+  "name": "ci-doctor",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ci-doctor",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/ci-doctor/package.json
+++ b/tools/ci-doctor/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ci-doctor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts",
+    "test": "tsx --test test.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.5.4",
+    "@types/node": "^20.14.0"
+  }
+}

--- a/tools/ci-doctor/test.ts
+++ b/tools/ci-doctor/test.ts
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { diagnose } from './index.ts';
+
+test('missing-secret failure → alert only, exact var name', () => {
+  const log = [
+    '##[group]Run actions/foo@v1',
+    'env:',
+    '  token: ',
+    '##[endgroup]',
+    'Error: Input required and not supplied: ANTHROPIC_API_KEY',
+    'Error: Process completed with exit code 1.',
+  ].join('\n');
+
+  const d = diagnose(log);
+  assert.equal(d.rule, 'missing_secret');
+  assert.equal(d.autoFixable, false);
+  assert.match(d.cause, /missing secret: ANTHROPIC_API_KEY/);
+  assert.match(d.suggestedFix, /Settings.+Secrets/);
+});
+
+test('missing-dependency failure → autoFixable, mentions package.json', () => {
+  const log = [
+    '> hive-baby@0.1.0 build',
+    '> next build',
+    '',
+    "Error: Cannot find module 'left-pad'",
+    'Require stack:',
+    '- /workspaces/hive-baby/scripts/build.js',
+    'npm ERR! code MODULE_NOT_FOUND',
+    "npm ERR! 404 'left-pad@*' is not in the npm registry.",
+  ].join('\n');
+
+  const d = diagnose(log);
+  assert.equal(d.rule, 'missing_dep');
+  assert.equal(d.autoFixable, true);
+  assert.match(d.cause, /missing dependency.*left-pad/);
+  assert.match(d.suggestedFix, /package\.json|npm ci/);
+});
+
+test('unknown failure → alert only, evidence contains log', () => {
+  const log = [
+    'Step 1: do a thing',
+    'Step 2: do another thing',
+    'Mystery error: 0xDEADBEEF',
+    'Build halted.',
+  ].join('\n');
+
+  const d = diagnose(log);
+  assert.equal(d.rule, 'unknown');
+  assert.equal(d.autoFixable, false);
+  assert.match(d.evidence, /Mystery error/);
+  assert.match(d.suggestedFix, /No rule matched|Manual review|diagnose/i);
+});


### PR DESCRIPTION
## What this PR delivers

The Hive **alert spine** (a `hive_alerts` Neon table + digest dispatcher) plus the first agent that writes to it: **ci-doctor**, which auto-diagnoses any failing GitHub Actions workflow.

This is one PR by design — ci-doctor depends on `hive_alerts`, and the digest agent is the only thing that turns those rows into emails. Merging them together keeps the spine consistent.

---

## Files & what each does

| File | Purpose |
|---|---|
| `migrations/001_hive_alerts.sql` | Creates `hive_alerts(id, tier, agent, subject, body, action_required, action_url, sent, created_at)` + unsent index. |
| `.github/workflows/run-migration.yml` | Manual `workflow_dispatch` that runs `psql -f migrations/<file>` against `DATABASE_URL` and prints `\d hive_alerts` + row count to confirm. **Delete this file in a follow-up commit after first successful run.** |
| `.github/workflows/digest.yml` + `scripts/digest.py` | Master digest agent. Triggers: `*/15 * * * *` (tier 1, real-time per row), `0 13 * * *` (tier 2, daily digest), `0 13 * * 1` (tier 3, weekly digest). Sends via Resend from `hive@hive.baby` to `saggarsonny@gmail.com`. Subjects: `HIVE DAILY — <date>` / `HIVE WEEKLY — <date>`. Marks rows `sent = true` only after Resend confirms HTTP 2xx. |
| `.github/workflows/ci-doctor.yml` | `workflow_run: [completed]` trigger; runs only when `conclusion == 'failure'` and skips its own runs. Permissions: `actions: read`, `contents: write`, `pull-requests: write`. |
| `tools/ci-doctor/index.ts` | The CLI: `fetchFailure(runId)` → `diagnose(log)` → `writeAlert(...)` → `maybeOpenPR(...)`. |
| `tools/ci-doctor/config.yml` | Runtime config (auto-fix toggle, whitelist, daily PR cap). |
| `tools/ci-doctor/test.ts` | Unit tests for the diagnose ruleset. |
| `tools/ci-doctor/package.json` + lockfile | tsx + node-test runner. |

---

## ci-doctor ruleset

| # | Trigger pattern | autoFixable | Action |
|---|---|---|---|
| 1 | `npm ERR! 404` / `Cannot find module 'X'` | ✅ (workflow-level only) | Suggest `npm i X` or switch to `npm ci`. |
| 2 | `Error: Input required and not supplied` / `secret X not found` | ❌ | Alert with exact secret name. |
| 3 | `No such file or directory: <path>` | ✅ (workflow path only) | Verify `working-directory:` and path. |
| 4 | `actions/X@vN ... deprecated` | ✅ | Bump `@vN` → `@v(N+1)` in the failing workflow file. |
| 5 | bare `exit 1..9` | ❌ | Alert with the 20 lines preceding the exit. |
| 6 | `Timeout` / `The operation was canceled` | ❌ | Alert only. |
| 7 | `ANTHROPIC*` / `STRIPE*` / `CLERK*` / `CF_*` / `VERCEL*` / `DATABASE_URL` mentioned with missing/required | ❌ | Alert with exact var name. |
| — | no match | ❌ | Alert with first 80 lines of failure log. |

---

## Safety rules (enforced in code, not config)

- **Whitelist**: `computePatch` and `maybeOpenPR` validate every output path against `^\.github/workflows/[A-Za-z0-9._-]+\.ya?ml$`. Anything else throws — no exceptions, including `package.json`.
- **No auto-merge**: PRs are opened as **draft** and never merged by ci-doctor.
- **Daily cap**: `max_auto_prs_per_day: 5` — checked via `search/issues?q=head:ci-doctor/ created:>=today` before opening. Prevents runaway loops if a fix breaks something.
- **No recursion**: workflow filters out `github.event.workflow_run.name == 'ci-doctor'` so it never diagnoses its own failures.
- **No app code, no secrets, no package.json edits.** Patch logic only ships for rule 4 today (action version bump). Rules 1 and 3 are flagged `autoFixable` per spec but `computePatch` returns `null` for them — they alert without a PR until a workflow-only patch path is wired up.

---

## How to disable

Delete `.github/workflows/ci-doctor.yml`. The digest and migration workflows are independent.

To pause auto-fix without disabling diagnosis: set `auto_fix_enabled: false` in `tools/ci-doctor/config.yml`.

---

## Required secrets

Add these in repo Settings → Secrets and variables → Actions before merging:

- `DATABASE_URL` — Neon connection string (used by run-migration, digest, and ci-doctor)
- `RESEND_API_KEY` — already present per `reddit-monitor.yml`; reused here

---

## Order to merge & first-run sequence

1. **Add `DATABASE_URL` secret** to the repo.
2. **Merge this PR**.
3. **Run** Actions → `run-migration` → `Run workflow` → leave default `001_hive_alerts.sql`. Confirm it logs `hive_alerts_rows` and the schema.
4. (Follow-up commit) Delete `.github/workflows/run-migration.yml` once migration is confirmed.
5. Digest agent starts producing emails on its next cron tick. ci-doctor starts diagnosing the next workflow failure automatically.

---

## Test results

```
TAP version 13
ok 1 - missing-secret failure → alert only, exact var name
ok 2 - missing-dependency failure → autoFixable, mentions package.json
ok 3 - unknown failure → alert only, evidence contains log
# tests 3
# pass 3
# fail 0
```

---

## Example alert email (tier 1, sent immediately)

> **From:** hive@hive.baby
> **To:** saggarsonny@gmail.com
> **Subject:** 🔧 CI failed: setup-hive-imr — missing secret: ANTHROPIC_API_KEY
>
> ```
> [ci-doctor] 🔧 CI failed: setup-hive-imr — missing secret: ANTHROPIC_API_KEY
>
> Workflow:     setup-hive-imr
> Workflow file:.github/workflows/setup-hive-imr.yml
> Job:          deploy
> Step:         Run anthropic call
>
> Cause:        missing secret: ANTHROPIC_API_KEY
> Rule:         missing_secret
> Auto-fixable: false
>
> Evidence:
> Error: Input required and not supplied: ANTHROPIC_API_KEY
> Error: Process completed with exit code 1.
>
> Suggested fix:
> Add secret `ANTHROPIC_API_KEY` in repo Settings → Secrets and variables →
> Actions, then re-run the failed job.
>
> Failing run: https://github.com/saggarsonny-boop/hivebaby/actions/runs/12345678
>
> Action: https://github.com/saggarsonny-boop/hivebaby/actions/runs/12345678
> At: 2026-05-02T13:42:11+00:00
> ```

---

_Stopping here per instructions. Awaiting review and merge._

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHTEa21FqyVTNFbH7g7gKd)_