### PR TITLE
feat: test-alert workflow for end-to-end digest verification

### DIFF
--- a/.github/workflows/test-alert.yml
+++ b/.github/workflows/test-alert.yml
@@ -1,0 +1,46 @@
+name: test-alert
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: 'Alert tier (1, 2, or 3)'
+        required: true
+        default: '2'
+      subject:
+        description: 'Alert subject'
+        required: true
+        default: 'TEST — alert spine live'
+      body:
+        description: 'Alert body'
+        required: true
+        default: 'If you are reading this, the spine works.'
+
+permissions:
+  contents: read
+
+jobs:
+  insert:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install psql client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client
+
+      - name: Insert alert into hive_alerts
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          TIER:    ${{ inputs.tier }}
+          SUBJECT: ${{ inputs.subject }}
+          BODY:    ${{ inputs.body }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DATABASE_URL:-}" ]; then
+            echo "DATABASE_URL secret not set" >&2
+            exit 1
+          fi
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+            -v tier="$TIER" \
+            -v subject="$SUBJECT" \
+            -v body="$BODY" \
+            -c "INSERT INTO hive_alerts (tier, agent, subject, body, action_required) VALUES (:'tier'::int, 'test-alert', :'subject', :'body', false) RETURNING id, tier, agent, subject, created_at;"


### PR DESCRIPTION
## What

Adds `.github/workflows/test-alert.yml` — a `workflow_dispatch`-only one-liner that inserts a row into `hive_alerts` with arbitrary tier/subject/body.

## Why

Lets you verify the digest pipeline end-to-end without waiting for a real alert. Defaults are pre-filled to match the verification you asked for:

- **tier:** `2`
- **subject:** `TEST — alert spine live`
- **body:** `If you are reading this, the spine works.`

After dispatch, the row should appear in the next **8am St Louis (13:00 UTC) daily digest** at `hive@hive.baby`, with subject `HIVE DAILY — <date>`.

## How to use

Actions tab → **test-alert** → **Run workflow** → leave defaults → Run.

Confirms via `RETURNING` clause that the insert landed (logs id + created_at).

## Order

Merge **after** `run-migration` has been dispatched and `hive_alerts` is confirmed to exist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHTEa21FqyVTNFbH7g7gKd)_