### PR TITLE
fix(ci-doctor): widen secret prefix regex to match real hivebaby names

### DIFF
--- a/tools/ci-doctor/index.ts
+++ b/tools/ci-doctor/index.ts
@@ -126,8 +126,11 @@ export async function fetchFailure(runId: number): Promise<FailureContext> {
 
 // ---------- diagnose ----------
 
+// Covers every secret prefix actually in use across the hivebaby repo.
+// Audit source: `grep -rhoE 'secrets\.[A-Z_][A-Z0-9_]+' .github/workflows scripts`.
+// If you add a new family of secrets, append its prefix here.
 const ENV_VAR_RE =
-  /\b(ANTHROPIC[A-Z0-9_]*|STRIPE[A-Z0-9_]*|CLERK[A-Z0-9_]*|CF_[A-Z0-9_]+|VERCEL[A-Z0-9_]*|DATABASE_URL)\b/;
+  /\b(ANTHROPIC[A-Z0-9_]*|STRIPE[A-Z0-9_]*|CLERK[A-Z0-9_]*|CF_[A-Z0-9_]+|CLOUDFLARE[A-Z0-9_]*|VERCEL[A-Z0-9_]*|RESEND[A-Z0-9_]*|NEON[A-Z0-9_]*|DATABASE_URL|CRON_SECRET|GH_PAT|GITHUB_TOKEN)\b/;
 
 export function diagnose(log: string): Diagnosis {
   const lines = log.split('\n');

--- a/tools/ci-doctor/test.ts
+++ b/tools/ci-doctor/test.ts
@@ -38,6 +38,53 @@ test('missing-dependency failure → autoFixable, mentions package.json', () => 
   assert.match(d.suggestedFix, /package\.json|npm ci/);
 });
 
+test('missing_secret extracts non-conventional names verbatim (CF_TOKEN, CLERK_SK, ANTHROPIC_KEY)', () => {
+  const cases: Array<[string, string]> = [
+    ['Error: Input required and not supplied: CF_TOKEN', 'CF_TOKEN'],
+    ['Error: Input required and not supplied: CLERK_SK', 'CLERK_SK'],
+    ['Error: Input required and not supplied: ANTHROPIC_KEY', 'ANTHROPIC_KEY'],
+    ['Error: secret RESEND_API_KEY not found', 'RESEND_API_KEY'],
+    ['Error: secret GH_PAT not found', 'GH_PAT'],
+  ];
+  for (const [log, name] of cases) {
+    const d = diagnose(log);
+    assert.equal(d.rule, 'missing_secret', `expected missing_secret for ${name}`);
+    assert.match(d.cause, new RegExp(`missing secret: ${name}`), `cause must include ${name}`);
+    assert.match(d.suggestedFix, new RegExp(`\`${name}\``), `fix must reference ${name}`);
+  }
+});
+
+test('missing_env_var detects every secret prefix actually used in the repo', () => {
+  const realNames = [
+    'ANTHROPIC_KEY',
+    'ANTHROPIC_API_KEY',
+    'CF_TOKEN',
+    'CF_API_TOKEN',
+    'CF_ACCOUNT',
+    'CF_ZONE',
+    'CLERK_PK',
+    'CLERK_SK',
+    'CLOUDFLARE_API_TOKEN',
+    'CLOUDFLARE_ZONE_ID',
+    'STRIPE_KEY',
+    'STRIPE_PK',
+    'STRIPE_SECRET_KEY',
+    'VERCEL_TOKEN',
+    'VERCEL_TOKEN_MAIN',
+    'RESEND_API_KEY',
+    'DATABASE_URL',
+    'CRON_SECRET',
+    'GH_PAT',
+    'GITHUB_TOKEN',
+  ];
+  for (const name of realNames) {
+    const log = `Error: ${name} is not set`;
+    const d = diagnose(log);
+    assert.equal(d.rule, 'missing_env_var', `expected missing_env_var for ${name} (got ${d.rule})`);
+    assert.match(d.cause, new RegExp(`missing env var: ${name}`));
+  }
+});
+
 test('unknown failure → alert only, evidence contains log', () => {
   const log = [
     'Step 1: do a thing',


### PR DESCRIPTION
## What I audited

```bash
grep -rhoE 'secrets\.[A-Z_][A-Z0-9_]+' .github/workflows scripts | sort -u
```

20 distinct secret names in active use. Cross-referenced against ci-doctor's `ENV_VAR_RE`.

## What was already correct

**Rule 2 (`missing_secret`)** extracts the literal name from log patterns like `Error: Input required and not supplied: <NAME>` and `Error: secret <NAME> not found`. It uses `[A-Za-z0-9_-]+` and was always agnostic to convention.

A test case has been added to lock this in: `CF_TOKEN`, `CLERK_SK`, `ANTHROPIC_KEY`, `RESEND_API_KEY`, `GH_PAT` all extract verbatim.

## What was wrong

**Rule 7 (`missing_env_var`)** scans log lines for hardcoded prefixes. The original regex covered `ANTHROPIC*|STRIPE*|CLERK*|CF_*|VERCEL*|DATABASE_URL`. Missing:

| Real name | Reason it was missed |
|---|---|
| `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID` | only `CF_*` short form was covered |
| `RESEND_API_KEY` | not in the original spec; but it's the digest's lifeline |
| `CRON_SECRET` | bespoke name |
| `GH_PAT`, `GITHUB_TOKEN` | bespoke names |

## The fix

```diff
-/\b(ANTHROPIC[A-Z0-9_]*|STRIPE[A-Z0-9_]*|CLERK[A-Z0-9_]*|CF_[A-Z0-9_]+|VERCEL[A-Z0-9_]*|DATABASE_URL)\b/
+/\b(ANTHROPIC[A-Z0-9_]*|STRIPE[A-Z0-9_]*|CLERK[A-Z0-9_]*|CF_[A-Z0-9_]+|CLOUDFLARE[A-Z0-9_]*|VERCEL[A-Z0-9_]*|RESEND[A-Z0-9_]*|NEON[A-Z0-9_]*|DATABASE_URL|CRON_SECRET|GH_PAT|GITHUB_TOKEN)\b/
```

Plus `NEON*` added defensively (the alert spine writes to Neon; future workflows may set `NEON_*` env vars).

## Tests

Two new test cases. All 20 real names pass:

```
ok 1 - missing-secret failure → alert only, exact var name
ok 2 - missing-dependency failure → autoFixable, mentions package.json
ok 3 - missing_secret extracts non-conventional names verbatim (CF_TOKEN, CLERK_SK, ANTHROPIC_KEY)
ok 4 - missing_env_var detects every secret prefix actually used in the repo
ok 5 - unknown failure → alert only, evidence contains log
# pass 5  fail 0
```

## Maintenance note

If you add a new family of secrets, append its prefix to `ENV_VAR_RE` and a test case. The comment above the regex points future maintainers at the audit command.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHTEa21FqyVTNFbH7g7gKd)_