### PR TITLE
fix(ci-doctor): add workflows list to workflow_run trigger

### DIFF
--- a/.github/workflows/ci-doctor.yml
+++ b/.github/workflows/ci-doctor.yml
@@ -1,6 +1,14 @@
 name: ci-doctor
 on:
   workflow_run:
+    workflows:
+      - "Health Check - All Hive Properties"
+      - "Schema Sheriff — Universal Document Routes"
+      - "hive-digest"
+      - "Reddit Monitor - Hive Lead Finder"
+      - "run-migration"
+      - "SSRN Watcher — Universal Document Paper"
+      - "Issue Fixer — Schema Violation Auto-Repair"
     types: [completed]
 
 permissions:


### PR DESCRIPTION
## Summary
- The `workflow_run` trigger requires a `workflows:` list naming the workflows to listen for. Without it, GitHub registers the workflow under its file path (`/.github/workflows/ci-doctor.yml`) instead of the `name:` field, and creates a phantom **startup-failure** run on every push to any branch — zero jobs, instant completion, log not found.
- Observed five times since PR #45 merged: ci-doctor.yml runs #1 (claude/ci-failure-… push), #2 (main merge `edbfee0`), #3 (feat/test-alert-workflow push), #4 (chore/remove-run-migration push), #5 (fix/ci-doctor-secret-names push).
- This change adds the missing `workflows:` list, scoped to the recurring agents we actually want auto-diagnosed on failure.

## Watched workflows
- `Health Check - All Hive Properties`
- `Schema Sheriff — Universal Document Routes`
- `hive-digest`
- `Reddit Monitor - Hive Lead Finder`
- `run-migration`
- `SSRN Watcher — Universal Document Paper`
- `Issue Fixer — Schema Violation Auto-Repair`

Trivial Ops one-shots (Vercel/CF setup workflows, deploy hooks) are intentionally excluded — they're manually triggered and short-lived.

## Why this clears the spurious failures
The phantom failures came from GitHub registering ci-doctor with an unparseable trigger config. With a valid `workflows:` list the trigger binds correctly, registration refreshes from path-as-name back to "ci-doctor" on the next valid trigger, and pushes that don't match a watched workflow no longer create startup-failure rows.

## Test plan
- [ ] Merge to main; confirm registration name flips from `.github/workflows/ci-doctor.yml` back to `ci-doctor` (sometimes needs one valid trigger to refresh).
- [ ] Verify a push to any branch no longer creates a `.github/workflows/ci-doctor.yml` failed run row.
- [ ] On the next failure of a watched workflow (e.g. health-check), confirm ci-doctor fires, runs `npm test` + `tsx index.ts`, and writes a `hive_alerts` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)