### PR TITLE
fix(health-check): tier engines so unbuilt ones don't fail the run

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -24,9 +24,13 @@ jobs:
           > /tmp/failures.txt
           FAILED=0
 
+          # Live tier: must be reachable and non-500.
+          # The `|| echo "000"` guards against curl exit codes (e.g. exit 6
+          # for unresolved DNS) propagating up and killing the whole step
+          # before later URLs are even attempted.
           check_url() {
             local NAME="$1" URL="$2"
-            STATUS=$(curl -s -o /tmp/rb.txt -w "%{http_code}" --max-time 20 -L "$URL" 2>/dev/null)
+            STATUS=$(curl -s -o /tmp/rb.txt -w "%{http_code}" --max-time 20 -L "$URL" 2>/dev/null || echo "000")
             if [ "$STATUS" = "500" ] || [ "$STATUS" = "000" ]; then
               echo "FAIL: $NAME -> $STATUS"
               BODY=$(head -c 120 /tmp/rb.txt | tr -d '\000')
@@ -37,7 +41,19 @@ jobs:
             fi
           }
 
-          # Core
+          # Building tier: per CLAUDE.md not yet live. Warn-only; does not
+          # set FAILED. Move back to live tier once the engine is live.
+          check_url_building() {
+            local NAME="$1" URL="$2"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -L "$URL" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "500" ] || [ "$STATUS" = "000" ]; then
+              echo "WARN (building): $NAME -> $STATUS — not yet live, skipping"
+            else
+              echo "OK   (building): $NAME -> $STATUS"
+            fi
+          }
+
+          # Core (live)
           check_url "hive.baby"           "https://hive.baby"
           check_url "HivePhoto"           "https://hivephoto.hive.baby"
           check_url "HiveTestingStation"  "https://test.hive.baby"
@@ -51,13 +67,15 @@ jobs:
           check_url "HiveSecretBox"       "https://secretbox.hive.baby"
           check_url "WhoTextedMe"         "https://whotextedme.hive.baby"
           check_url "HiveAdminSupport"    "https://support.hive.baby"
-          check_url "HiveMeme"            "https://hivememe.hive.baby"
           check_url "HiveAestheticBestie" "https://hiveaestheticbestie.hive.baby"
           check_url "HiveMicroRitual"     "https://hivemicroritual.hive.baby"
           check_url "SovereignArbitrage"  "https://sovereignarbitrage.hive.baby"
           check_url "HiveIMR"             "https://hiveimr.hive.baby/api/health"
-          check_url "HivePlainScan"       "https://plainscan.hive.baby/api/health"
           check_url "QueenBee"            "https://queenbee.hive.baby"
+
+          # Building (CLAUDE.md status: BUILDING) — warn only
+          check_url_building "HiveMeme"      "https://hivememe.hive.baby"
+          check_url_building "HivePlainScan" "https://plainscan.hive.baby/api/health"
           # UD
           check_url "ud.hive.baby"        "https://ud.hive.baby"
           check_url "UDUtilities"         "https://utilities.hive.baby"
@@ -80,7 +98,7 @@ jobs:
           S=$(curl -s -o /tmp/rb.txt -w "%{http_code}" -X POST "https://test.hive.baby/api/apply" \
             -H "Content-Type: application/json" \
             -d '{"name":"hc","email":"hc@hive.baby","engineSlug":"hivephoto","country":"GB","device":"desktop","browser":"chrome","agreedFeedback":true,"honeypot":"bot"}' \
-            --max-time 20 2>/dev/null)
+            --max-time 20 2>/dev/null || echo "000")
           if [ "$S" = "500" ] || [ "$S" = "000" ]; then
             echo "FAIL: apply honeypot -> $S (crash)"
             printf '**test.hive.baby/api/apply (honeypot)**\n- HTTP %s (crash, expected 400)\n- Body: `%s`\n\n' \
@@ -93,7 +111,7 @@ jobs:
           # API smoke: fake verify token -> must NOT be 500
           S=$(curl -s -o /tmp/rb.txt -w "%{http_code}" \
             "https://test.hive.baby/api/verify?token=hc-fake-$(date +%s)" \
-            --max-time 20 2>/dev/null)
+            --max-time 20 2>/dev/null || echo "000")
           if [ "$S" = "500" ]; then
             echo "FAIL: verify fake token -> $S"
             printf '**test.hive.baby/api/verify (fake token)**\n- HTTP %s (crash)\n\n' "$S" >> /tmp/failures.txt


### PR DESCRIPTION
## Summary
- Health Check run #52 on the PR-#45 merge commit (`edbfee0`) exited with code **6** right after `OK: HiveIMR -> 200`. Code 6 is curl's "couldn't resolve host" — the next URL was `https://plainscan.hive.baby/api/health`, which isn't wired in DNS yet (HivePlainScan status is **BUILDING** per CLAUDE.md). Under the runner's default `bash -eo pipefail`, the curl exit propagated through and killed the step before later URLs were even attempted.
- This PR splits the engine list into a **live** tier (must pass) and a **building** tier (warn-only), and hardens every `curl` against propagating exit codes.

## Engines moved to building tier
Per CLAUDE.md status `BUILDING`:
- **HiveMeme** (`hivememe.hive.baby`)
- **HivePlainScan** (`plainscan.hive.baby/api/health`)

Both flip back to the live tier the moment DNS is wired and the engine reports 200.

## Two changes
1. **`check_url_building` helper** — warns but never sets `FAILED=1`. The run cannot turn red because of an unbuilt engine.
2. **`|| echo "000"` on every curl** — failed curl resolves to `STATUS="000"` instead of letting bash propagate curl's exit code. The `"000"` branch was already handled (FAIL + `FAILED=1` for live; WARN-only for building), so this guards the live tier against the same DNS-resolution-kills-script bug we just observed.

Net effect: the run only fails when a live-tier engine returns 500 or 000. Anything BUILDING is logged but does not turn the build red.

## Test plan
- [ ] Merge to main; the next scheduled (or push-triggered) Health Check run should print `WARN (building): HivePlainScan -> 000` and finish green.
- [ ] When `plainscan.hive.baby` DNS goes live, move `check_url_building "HivePlainScan"` back to the live `check_url` block. Same for HiveMeme when ready.
- [ ] Verify the API smoke checks (apply honeypot, verify fake token) still flag genuine 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)