### PR TITLE
fix(health-check): stop appending 000 on curl failure (was masking real DNS failures)

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -25,12 +25,19 @@ jobs:
           FAILED=0
 
           # Live tier: must be reachable and non-500.
-          # The `|| echo "000"` guards against curl exit codes (e.g. exit 6
-          # for unresolved DNS) propagating up and killing the whole step
-          # before later URLs are even attempted.
+          # `if STATUS=$(...)` consumes curl's exit code so a non-zero
+          # curl (e.g. exit 6 for unresolved DNS) can't propagate up and
+          # kill the step. On failure we explicitly set STATUS=000;
+          # *not* `|| echo "000"`, which would append to whatever curl
+          # already wrote via -w and yield STATUS="000000".
           check_url() {
             local NAME="$1" URL="$2"
-            STATUS=$(curl -s -o /tmp/rb.txt -w "%{http_code}" --max-time 20 -L "$URL" 2>/dev/null || echo "000")
+            local STATUS
+            if STATUS=$(curl -s -o /tmp/rb.txt -w "%{http_code}" --max-time 20 -L "$URL" 2>/dev/null); then
+              :
+            else
+              STATUS="000"
+            fi
             if [ "$STATUS" = "500" ] || [ "$STATUS" = "000" ]; then
               echo "FAIL: $NAME -> $STATUS"
               BODY=$(head -c 120 /tmp/rb.txt | tr -d '\000')
@@ -45,7 +52,12 @@ jobs:
           # set FAILED. Move back to live tier once the engine is live.
           check_url_building() {
             local NAME="$1" URL="$2"
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -L "$URL" 2>/dev/null || echo "000")
+            local STATUS
+            if STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -L "$URL" 2>/dev/null); then
+              :
+            else
+              STATUS="000"
+            fi
             if [ "$STATUS" = "500" ] || [ "$STATUS" = "000" ]; then
               echo "WARN (building): $NAME -> $STATUS — not yet live, skipping"
             else
@@ -95,10 +107,10 @@ jobs:
           check_url "HiveMoon API"        "https://hivemoon.hive.baby/api/moon"
 
           # API smoke: honeypot -> must NOT be 500
-          S=$(curl -s -o /tmp/rb.txt -w "%{http_code}" -X POST "https://test.hive.baby/api/apply" \
+          if S=$(curl -s -o /tmp/rb.txt -w "%{http_code}" -X POST "https://test.hive.baby/api/apply" \
             -H "Content-Type: application/json" \
             -d '{"name":"hc","email":"hc@hive.baby","engineSlug":"hivephoto","country":"GB","device":"desktop","browser":"chrome","agreedFeedback":true,"honeypot":"bot"}' \
-            --max-time 20 2>/dev/null || echo "000")
+            --max-time 20 2>/dev/null); then :; else S="000"; fi
           if [ "$S" = "500" ] || [ "$S" = "000" ]; then
             echo "FAIL: apply honeypot -> $S (crash)"
             printf '**test.hive.baby/api/apply (honeypot)**\n- HTTP %s (crash, expected 400)\n- Body: `%s`\n\n' \
@@ -109,9 +121,9 @@ jobs:
           fi
 
           # API smoke: fake verify token -> must NOT be 500
-          S=$(curl -s -o /tmp/rb.txt -w "%{http_code}" \
+          if S=$(curl -s -o /tmp/rb.txt -w "%{http_code}" \
             "https://test.hive.baby/api/verify?token=hc-fake-$(date +%s)" \
-            --max-time 20 2>/dev/null || echo "000")
+            --max-time 20 2>/dev/null); then :; else S="000"; fi
           if [ "$S" = "500" ]; then
             echo "FAIL: verify fake token -> $S"
             printf '**test.hive.baby/api/verify (fake token)**\n- HTTP %s (crash)\n\n' "$S" >> /tmp/failures.txt


### PR DESCRIPTION
## Summary
PR #50 introduced a regression. The pattern

```bash
STATUS=$(curl ... -w "%{http_code}" 2>/dev/null || echo "000")
```

doesn't *replace* curl's stdout on failure — it **appends**. curl with `-w "%{http_code}"` writes \`000\` to stdout AND exits non-zero on DNS-resolution failure, so the \`|| echo "000"\` clause runs and emits another \`000\`. \`STATUS\` ends up \`000000\`.

The check \`[ "\$STATUS" = "500" ] || [ "\$STATUS" = "000" ]\` doesn't match \`000000\`, so the live-tier \`check_url\` falls into the OK branch and silently reports the URL as healthy.

## Evidence
In Health Check [run 25255777523](https://github.com/saggarsonny-boop/hivebaby/actions/runs/25255777523) (post-PR-#50, commit \`12ca77b6\`), five short-alias domains that do not resolve in DNS were reported as healthy:

```
OK:   moon.hive.baby      -> 000000
OK:   clock.hive.baby     -> 000000
OK:   bodylog.hive.baby   -> 000000
OK:   secret.hive.baby    -> 000000
OK:   aesthetic.hive.baby -> 000000
```

## Fix
Replace the broken \`||\` clause with an explicit \`if\`-test that consumes curl's exit code and only sets \`STATUS=000\` in the failure branch, never appending:

```bash
local STATUS
if STATUS=$(curl ... 2>/dev/null); then
  :
else
  STATUS="000"
fi
```

Same pattern applied to both \`check_url\` / \`check_url_building\` helpers and the two API smoke checks. The exit-code-propagation guard that motivated PR #50's original \`||\` clause is preserved — curl's non-zero exit is consumed by the \`if\`-test, so \`bash -eo pipefail\` cannot propagate it.

## Expected post-merge behaviour
The five short aliases above will start reporting \`FAIL: ... -> 000\` and the run will turn red. **That is the correct behaviour** — they genuinely don't resolve. Either wire DNS for those subdomains or move them out of the live tier in a follow-up.

## Test plan
- [ ] Merge to main; the next Health Check run prints \`FAIL: moon.hive.baby -> 000\` (and similarly for clock/bodylog/secret/aesthetic).
- [ ] HivePlainScan continues to report \`WARN (building): HivePlainScan -> 000 — not yet live, skipping\` (correct format, no doubling).
- [ ] Live-tier engines that genuinely return 200 still report \`OK: ... -> 200\`.
- [ ] Decide whether to wire DNS for the short aliases or move them to the building tier (out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)