### PR TITLE
docs(issue-fixer): document GH_PAT requirement, improve degraded-mode comment

### DIFF
--- a/.github/workflows/issue-fixer.yml
+++ b/.github/workflows/issue-fixer.yml
@@ -1,5 +1,19 @@
 name: Issue Fixer — Schema Violation Auto-Repair
 
+# Auth model:
+#   GITHUB_TOKEN — issued by Actions, scoped to this repo only. Used to comment
+#                  on and close the schema-violation issue here in hivebaby.
+#   GH_PAT       — REQUIRED for the auto-repair step. Schema violations live in
+#                  the saggarsonny-boop/universal-document repo, and the default
+#                  GITHUB_TOKEN cannot push to a different repo. To enable full
+#                  auto-repair, add a Personal Access Token as `GH_PAT` with:
+#                    • Classic: `repo` scope (write access to universal-document)
+#                    • Fine-grained: Contents:Write on saggarsonny-boop/universal-document
+#                  When GH_PAT is missing, scripts/issue_fixer.py degrades
+#                  gracefully — it posts a comment on the issue explaining the
+#                  gap and exits cleanly. The workflow run will show as success.
+#   ANTHROPIC_API_KEY — for the Claude call that generates the fix.
+
 on:
   issues:
     types: [opened]

--- a/scripts/issue_fixer.py
+++ b/scripts/issue_fixer.py
@@ -168,8 +168,17 @@ def main() -> None:
     if not GH_PAT:
         msg = (
             "**Auto-fix skipped** — `GH_PAT` secret not set in hivebaby Actions secrets.\n\n"
-            "Add a Personal Access Token with `repo` scope as `GH_PAT` to enable "
-            "cross-repo auto-fixes. Fix this violation manually and close this issue."
+            "**Why this is needed:** the schema violations live in `saggarsonny-boop/universal-document`. "
+            "The default `GITHUB_TOKEN` issued to this Action is scoped to `hivebaby` only and cannot "
+            "push to a different repo, so the auto-fix needs a Personal Access Token.\n\n"
+            "**To enable auto-fix:**\n"
+            "1. Create a PAT — either:\n"
+            "   - **Classic** with `repo` scope, or\n"
+            "   - **Fine-grained** with Contents:Write on `saggarsonny-boop/universal-document` "
+            "(more secure, recommended).\n"
+            "2. Add it as repo secret `GH_PAT` at "
+            "Settings → Secrets and variables → Actions → New repository secret.\n\n"
+            "**For now:** apply the fix manually, then close this issue."
         )
         comment_issue(msg)
         print("GH_PAT not set — commented on issue and exiting")


### PR DESCRIPTION
## Summary

\`GH_PAT\` is referenced in \`issue-fixer.yml\` but doesn't exist in this repo's Actions secrets. The script already degrades gracefully (posts a comment on the violation issue, exits 0), but two things were under-documented:

- The workflow YAML had no description of the auth model.
- The in-issue comment didn't explain *why* the PAT is needed or what scope it should have.

This PR adds documentation only — no behaviour change.

## Why I didn't rewrite to use GITHUB_TOKEN

The brief offered "rewrite to use GITHUB_TOKEN if scopes allow" as an option. Scopes don't allow it:

- The schema violations live in \`saggarsonny-boop/universal-document\`.
- The auto-fix step pushes a fixed file to that repo.
- The default \`GITHUB_TOKEN\` issued to a hivebaby Action is scoped to hivebaby only — it cannot push to a different repo.

Removing the GH_PAT requirement would mean either (a) moving the schema-sheriff route files into hivebaby, or (b) switching from direct push to a PR-based flow using a GitHub App installation token. Both are bigger refactors and out of scope for this PR.

## Changes

1. \`.github/workflows/issue-fixer.yml\` — header comment describing the three secrets (GITHUB_TOKEN, GH_PAT, ANTHROPIC_API_KEY), what each is for, what's required for full auto-fix, and the graceful-degradation behaviour.
2. \`scripts/issue_fixer.py\` — the auto-fix-skipped comment posted on schema-violation issues is now actionable: explains the cross-repo-write reason, lists both classic-PAT (\`repo\`) and fine-grained-PAT (Contents:Write on universal-document) options, recommends fine-grained, and gives the Settings → Secrets click path.

## To enable full auto-fix later

Add a Personal Access Token as the repo secret \`GH_PAT\`:
- **Classic:** \`repo\` scope.
- **Fine-grained:** \`Contents:Write\` on \`saggarsonny-boop/universal-document\` (recommended — narrower blast radius).

Click path: Settings → Secrets and variables → Actions → New repository secret.

## Test plan

- [ ] When the next schema-violation issue opens (or a synthetic one is created with the \`schema-violation\` label), the workflow posts the new, more-actionable comment instead of the prior generic message.
- [ ] Verify the YAML parses (no \`name:\` change, no trigger change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)