### PR TITLE
chore(parkback): operational finalization — footer, registries, archive

### DIFF
--- a/apps/parkback/app/_lib/HiveFooter.tsx
+++ b/apps/parkback/app/_lib/HiveFooter.tsx
@@ -1,0 +1,72 @@
+// Standard Hive footer used on every screen of every engine.
+// Pattern matches hive-aestheticbestie's tagline + the canonical hive.baby
+// link set (about / contribute / patrons / privacy / homepage).
+
+const GOLD_DIM = "#8a6f1f";
+const MUTED = "#9a9588";
+
+const linkBase: React.CSSProperties = {
+  color: MUTED,
+  textDecoration: "none",
+  borderBottom: `1px dotted ${MUTED}`,
+  paddingBottom: 1,
+};
+
+const dotStyle: React.CSSProperties = {
+  color: GOLD_DIM,
+  margin: "0 6px",
+};
+
+export function HiveFooter() {
+  return (
+    <footer style={footerStyle}>
+      <div>No ads. No investors. No agenda.</div>
+      <div>Free at the base tier, forever.</div>
+      <nav style={linkRowStyle} aria-label="Hive links">
+        <a href="https://hive.baby" target="_blank" rel="noopener noreferrer" style={linkBase}>
+          hive.baby
+        </a>
+        <span style={dotStyle}>·</span>
+        <a href="https://hive.baby/about.html" target="_blank" rel="noopener noreferrer" style={linkBase}>
+          social experiment
+        </a>
+        <span style={dotStyle}>·</span>
+        <a href="https://hive.baby/contribute.html" target="_blank" rel="noopener noreferrer" style={linkBase}>
+          contribute
+        </a>
+        <span style={dotStyle}>·</span>
+        <a href="https://hive.baby/patrons.html" target="_blank" rel="noopener noreferrer" style={linkBase}>
+          patronage
+        </a>
+        <span style={dotStyle}>·</span>
+        <a href="https://hive.baby/privacy.html" target="_blank" rel="noopener noreferrer" style={linkBase}>
+          privacy
+        </a>
+      </nav>
+    </footer>
+  );
+}
+
+const footerStyle: React.CSSProperties = {
+  marginTop: 18,
+  color: MUTED,
+  fontSize: 11,
+  letterSpacing: "0.05em",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 4,
+  lineHeight: 1.6,
+  padding: "0 16px",
+  textAlign: "center",
+};
+
+const linkRowStyle: React.CSSProperties = {
+  marginTop: 6,
+  display: "flex",
+  flexWrap: "wrap",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: 0,
+  fontSize: 11,
+};

--- a/apps/parkback/app/find/page.tsx
+++ b/apps/parkback/app/find/page.tsx
@@ -14,6 +14,7 @@ import { useCompass } from "../_lib/useCompass";
 import { Figure8 } from "../_lib/Figure8";
 import { track } from "../_lib/analytics";
 import { recipientHomeUrl } from "../_lib/share";
+import { HiveFooter } from "../_lib/HiveFooter";
 
 const GOLD = "#D4AF37";
 const GOLD_DIM = "#8a6f1f";
@@ -168,12 +169,7 @@ function FindInner() {
         Get ParkBack for your own car →
       </a>
 
-      <footer style={footerStyle}>
-        <div>No ads. No investors. No agenda.</div>
-        <a href="https://hive.baby" target="_blank" rel="noopener noreferrer" style={hiveLinkStyle}>
-          part of the Hive
-        </a>
-      </footer>
+      <HiveFooter />
     </main>
   );
 }
@@ -244,14 +240,6 @@ const primaryActionStyle: React.CSSProperties = {
 const smallButtonStyle: React.CSSProperties = {
   background: "transparent", color: GOLD, border: `1px solid ${GOLD}`, borderRadius: 8,
   padding: "6px 12px", fontSize: 13, fontWeight: 600, cursor: "pointer",
-};
-const footerStyle: React.CSSProperties = {
-  marginTop: 18, color: MUTED, fontSize: 11, letterSpacing: "0.05em",
-  display: "flex", flexDirection: "column", alignItems: "center", gap: 6,
-};
-const hiveLinkStyle: React.CSSProperties = {
-  color: MUTED, textDecoration: "none", fontSize: 11, letterSpacing: "0.05em",
-  borderBottom: `1px dotted ${MUTED}`, paddingBottom: 1,
 };
 const recipientCtaStyle: React.CSSProperties = {
   marginTop: 4, color: GOLD, textDecoration: "none", fontSize: 13, fontWeight: 600,

--- a/apps/parkback/app/page.tsx
+++ b/apps/parkback/app/page.tsx
@@ -12,6 +12,7 @@ import { useCompass } from "./_lib/useCompass";
 import { Figure8 } from "./_lib/Figure8";
 import { track } from "./_lib/analytics";
 import { buildShareUrl } from "./_lib/share";
+import { HiveFooter } from "./_lib/HiveFooter";
 
 const STORAGE_KEY = "parkback_pin_v1";
 const A2HS_DISMISSED_KEY = "parkback_a2hs_dismissed_v1";
@@ -460,12 +461,7 @@ export default function ParkBackPage() {
             : "Tap when you've parked. Works offline once installed."}
         </div>
 
-        <footer style={footerStyle}>
-          <div>No ads. No investors. No agenda.</div>
-          <a href="https://hive.baby" target="_blank" rel="noopener noreferrer" style={hiveLinkStyle}>
-            part of the Hive
-          </a>
-        </footer>
+        <HiveFooter />
       </main>
     );
   }
@@ -602,12 +598,7 @@ export default function ParkBackPage() {
         </div>
       ) : null}
 
-      <footer style={footerStyle}>
-        <div>No ads. No investors. No agenda.</div>
-        <a href="https://hive.baby" target="_blank" rel="noopener noreferrer" style={hiveLinkStyle}>
-          part of the Hive
-        </a>
-      </footer>
+      <HiveFooter />
 
       {toast ? <div role="status" style={toastStyle}>{toast}</div> : null}
     </main>
@@ -846,26 +837,6 @@ const ghostActionStyle: React.CSSProperties = {
   fontSize: 14,
   cursor: "pointer",
   flex: "1 1 100px",
-};
-
-const footerStyle: React.CSSProperties = {
-  marginTop: 18,
-  color: MUTED,
-  fontSize: 11,
-  letterSpacing: "0.05em",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  gap: 6,
-};
-
-const hiveLinkStyle: React.CSSProperties = {
-  color: MUTED,
-  textDecoration: "none",
-  fontSize: 11,
-  letterSpacing: "0.05em",
-  borderBottom: `1px dotted ${MUTED}`,
-  paddingBottom: 1,
 };
 
 const a2hsStyle: React.CSSProperties = {

--- a/docs/engine-archives/parkback/ENGINE_GRAMMAR.md
+++ b/docs/engine-archives/parkback/ENGINE_GRAMMAR.md
@@ -1,0 +1,78 @@
+# ENGINE GRAMMAR — ParkBack
+
+<GrapplerHook>
+engine: ParkBack
+id: parkback
+version: 0.1.0
+governance: QueenBee.MasterGrappler
+safety: enabled
+multilingual: pending
+premium: false
+status: building
+tier: 1
+schema: parking-spot-pin
+stack: [nextjs, typescript]
+</GrapplerHook>
+
+## Engine Identity
+- **Name:** ParkBack
+- **Domain:** parkback.hive.baby
+- **Repo:** saggarsonny-boop/hivebaby (subdir `apps/parkback/`)
+- **Status:** Building (Tier 1)
+- **Stack:** Next.js + TypeScript (no AI, no backend, no database)
+
+## Purpose
+ParkBack is a client-only PWA that helps you remember where you parked. The
+pin, the photo, and the voice memo all live in `localStorage` on the device
+that dropped them. Nothing is uploaded. Nothing is synced. The shared spot
+link only carries coordinates and a landmark string — never media.
+
+## Inputs
+- High-accuracy `getCurrentPosition` (lat, lng, accuracy, altitude, heading, timestamp)
+- Optional rear-camera photo (compressed to 800px JPEG @ 0.7)
+- Optional 30-second voice memo (webm/opus)
+- Live `watchPosition` for distance + bearing while finding the car
+- `DeviceOrientationEvent` compass for arrow rotation (with iOS 13+ permission flow)
+
+## Outputs
+- A pin saved to `localStorage` under key `parkback_pin_v1`
+- A find view with rotating bearing arrow, distance, landmark, elapsed time
+- A `Navigate` deep-link: `maps://` on iOS, `geo:` on Android, Google Maps web on desktop
+- A shareable URL: `parkback.hive.baby/find?lat=…&lng=…&t=…&landmark=…`
+- A read-only `/find` route for recipients of a shared link
+
+## Storage schema (localStorage `parkback_pin_v1`)
+```json
+{
+  "lat": 37.7749,
+  "lng": -122.4194,
+  "accuracy": 8,
+  "altitude": 12,
+  "heading": null,
+  "timestamp": 1714780800000,
+  "landmark": "Market St, SoMa",
+  "photo": "data:image/jpeg;base64,…",
+  "voiceMemo": "data:audio/webm;base64,…"
+}
+```
+
+## Network calls
+- `nominatim.openstreetmap.org/reverse` — one read on pin drop, no key, no UA header (browser default)
+- No other outbound calls. No analytics. No telemetry.
+
+## Safety
+- Permission denial messaging is direct, no corporate language
+- Photo + voice memo never leave the source device
+- Share link contains only lat/lng/timestamp/landmark
+- Service worker caches the shell so the app loads in underground garages with no signal
+
+## Onboarding
+- Drop-pin button is the entire onboarding for the parking flow
+- First-visit copy: "Find your car. No accounts. No cloud."
+- Footer on every screen: "No ads. No investors. No agenda."
+
+## Out of scope (v0.1.0)
+- Multi-pin history
+- Parking timer / meter alerts
+- Routing inside the app (we deep-link to maps)
+- Anything that requires a backend

--- a/docs/engine-archives/parkback/README.md
+++ b/docs/engine-archives/parkback/README.md
@@ -1,0 +1,40 @@
+# ParkBack
+
+Drop a pin where you parked. Walk back to it. Nothing leaves the device.
+
+A client-only PWA. No accounts, no backend, no database. The pin, the photo,
+and the voice memo all live in `localStorage` on the device that dropped them.
+
+- **Domain:** parkback.hive.baby
+- **Repo:** `apps/parkback/` inside `saggarsonny-boop/hivebaby`
+- **Stack:** Next.js 16 + TypeScript
+
+## Routes
+
+| Path | What it does |
+|------|--------------|
+| `/` | Drop-pin / find-my-car (uses local pin from `localStorage`) |
+| `/find?lat=…&lng=…&t=…&landmark=…` | Read-only view of a spot someone shared with you |
+
+## Local dev
+
+```bash
+cd apps/parkback
+npm install
+npm run dev
+# → http://localhost:3000
+```
+
+## Deploy
+
+Vercel project on `saggarsonny-3909s-projects`. Root directory: `apps/parkback`.
+Domain: `parkback.hive.baby` via Cloudflare CNAME → `cname.vercel-dns.com`.
+No env vars required.
+
+## What it doesn't do
+- Doesn't sync anything anywhere
+- Doesn't track you
+- Doesn't show ads
+- Doesn't upload your photo or voice memo to a server (they stay on your phone)
+
+No ads. No investors. No agenda.

--- a/docs/engine-archives/parkback/test-station-slot.md
+++ b/docs/engine-archives/parkback/test-station-slot.md
@@ -1,0 +1,37 @@
+# test.hive.baby slot — ParkBack
+
+Paste-ready slot definition for the test.hive.baby engine_slots registry once that surface exists or via manual dashboard edit. Mirrors the 10-item launch checklist structure referenced in `CLAUDE.md` and stubbed in `tools/hive-finalize/checklist.ts:28`.
+
+## Slot metadata
+
+```yaml
+id: parkback
+name: ParkBack
+url: https://parkback.hive.baby
+repo: saggarsonny-boop/hivebaby
+subdir: apps/parkback
+version: v0.1
+shipped: 2026-05-04
+category: utility
+```
+
+## 10-item testing checklist
+
+| # | Test | Pass criteria |
+|---|------|----------------|
+| 1 | Drop pin (no permission) | Tap Drop pin → browser permission prompt appears |
+| 2 | Drop pin (granted) | Pin saved to `localStorage.parkback_pin_v1`; UI flips to find view within 2 s |
+| 3 | Reverse-geocode landmark | Within 5 s of pin drop, "near {landmark}" appears (Nominatim) |
+| 4 | Photo capture | Tap Take photo → rear camera opens (`capture="environment"`); after capture, thumbnail appears in find view; image is base64 in pin |
+| 5 | Voice memo | Tap Record → 30 s cap; playback control appears after stop |
+| 6 | Compass calibration (iOS) | First gesture triggers `DeviceOrientationEvent.requestPermission()`; figure-8 hint shows during calibration; arrow goes live within 5 s of waving |
+| 7 | Compass north-up fallback | On a desktop browser without orientation events, arrow points to absolute bearing with hint text |
+| 8 | Navigate deep-link | iOS opens Apple Maps; Android opens system map chooser via `geo:` |
+| 9 | Share spot | Web Share API on mobile / clipboard fallback on desktop with toast "Link copied"; URL includes `utm_source=share&utm_medium=link` |
+| 10 | Recipient view | `/find?lat=…&lng=…&t=…&landmark=…` renders distance, bearing, navigate button, and "Get ParkBack for your own car →" CTA pointing back with `utm_source=shared_recipient` |
+
+## Known limitations to note
+
+- Service worker assumes `parkback.hive.baby` root scope — local dev must be at port root, not behind a path prefix
+- iOS Safari requires "Add to Home Screen" before `prompt()`-style install banner is offered
+- Plausible script blocked by uBlock Origin / Brave shields → events silently dropped (acceptable, no-data fallback)

--- a/registry/billing-reconciliation.md
+++ b/registry/billing-reconciliation.md
@@ -1,0 +1,7 @@
+# Hive Billing Reconciliation
+
+Per-engine cost-of-goods-sold estimate and pricing tier. Used to track which engines are net cost vs net contribution to Hive ops. Append-only.
+
+| Engine | Monthly COGS estimate | Pricing tier | Status | Notes |
+|---|---|---|---|---|
+| ParkBack | ~$0 | free forever | shipped | Client-only PWA, no backend, no DB. Vercel hobby tier (free). Plausible analytics free trial then $9/mo if kept. Reverse geocoding via Nominatim (free, no key). No infra cost beyond Vercel-hobby + the optional Plausible. |

--- a/registry/dns-inventory.md
+++ b/registry/dns-inventory.md
@@ -1,0 +1,7 @@
+# Hive DNS Inventory
+
+Subdomains under `hive.baby` (Cloudflare zone `bcb5522993ecf90a4f1d5dfe101e5a5c`). Append-only. All engine subdomains CNAME to `cname.vercel-dns.com`.
+
+| Subdomain | Target | Type | Registered date | Notes |
+|---|---|---|---|---|
+| parkback.hive.baby | cname.vercel-dns.com | CNAME | _pending_ | CNAME not yet created — awaiting `CF_API_TOKEN` in Codespace secrets. Vercel project: `hivebaby-7c1o` (root: `apps/parkback`). |

--- a/registry/engines.md
+++ b/registry/engines.md
@@ -1,0 +1,7 @@
+# Hive Engine Registry
+
+Canonical operational list of shipped engines. Append-only — append a row when an engine ships, update the `status` and `version` columns when an engine evolves. The structured machine-readable list is in `engines.json` at the repo root.
+
+| Name | Repo | Domain | Version | Status | Deploy date | Owner |
+|---|---|---|---|---|---|---|
+| ParkBack | saggarsonny-boop/hivebaby (apps/parkback) | parkback.hive.baby | v0.1 | shipped | 2026-05-04 | Sonny |


### PR DESCRIPTION
## Summary

Operational finalization for ParkBack. Everything that the launch-checklist brief asked for that's executable from the Codespace without external tokens. Companion to #58 (subproject) and #59 (SEO/UX).

### Standard Hive footer

- New `apps/parkback/app/_lib/HiveFooter.tsx` with the canonical link set:
  > `hive.baby · social experiment · contribute · patronage · privacy`
- Plus the standard taglines: "No ads. No investors. No agenda." and "Free at the base tier, forever."
- Both `/` and `/find` swap their inline footers for `<HiveFooter />`. Removes ~40 lines of duplicated styling.

### Flat-file registries (new — canonical operational ledger)

| File | Purpose |
|------|---------|
| `registry/engines.md` | Append-only engine ledger (name, repo, domain, version, status, deploy date, owner). |
| `registry/dns-inventory.md` | Subdomain ledger. `parkback.hive.baby` row marked **pending** — CNAME not yet created. |
| `registry/billing-reconciliation.md` | Per-engine COGS estimate. ParkBack ~$0/mo (client-only PWA). |

These are the operational source of truth for what's shipped, what's wired, and what costs what. Recommend pointing `CLAUDE.md` at them next session — the tables in CLAUDE.md drift; these append-only files don't.

### Spec archival

- `docs/engine-archives/parkback/ENGINE_GRAMMAR.md`
- `docs/engine-archives/parkback/README.md`
- `docs/engine-archives/parkback/test-station-slot.md` — paste-ready slot definition for `test.hive.baby` (when that surface exists) plus the canonical 10-item launch checklist scoped to ParkBack.

## Test plan

- [x] `npx next build` clean
- [x] No layout regression — same gold/black, same dimensions, footer rendered consistently across both routes
- [ ] Phone QA: confirm the new footer link row wraps gracefully on a small viewport

## Why a separate PR

PR #59 was already merged to main when this work began. This PR is purely additive (only **new** files in `registry/` and `docs/engine-archives/parkback/`, plus the footer extraction touching `app/page.tsx` + `app/find/page.tsx`). Safe to merge after a quick visual check on a phone.

https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv)_