### PR TITLE
chore(parkback): mark parkback.hive.baby DNS row as live

### DIFF
--- a/registry/dns-inventory.md
+++ b/registry/dns-inventory.md
@@ -4,4 +4,4 @@ Subdomains under `hive.baby` (Cloudflare zone `bcb5522993ecf90a4f1d5dfe101e5a5c`
 
 | Subdomain | Target | Type | Registered date | Notes |
 |---|---|---|---|---|
-| parkback.hive.baby | cname.vercel-dns.com | CNAME | _pending_ | CNAME not yet created — awaiting `CF_API_TOKEN` in Codespace secrets. Vercel project: `hivebaby-7c1o` (root: `apps/parkback`). |
+| parkback.hive.baby | cname.vercel-dns.com | CNAME | 2026-05-04 | Live. Vercel project: `hivebaby-7c1o` (root: `apps/parkback`). |


### PR DESCRIPTION
One-line cosmetic fix: flip `_pending_` → `2026-05-04` in the `parkback.hive.baby` row of `registry/dns-inventory.md` now that the CNAME is live (resolves to Vercel anycast `216.150.1.193`).

Will mark ready and merge as soon as CI is green per the standing rule.

https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv)_