### PR TITLE
feat(parkback): first-use onboarding banner + explainer; checklist update

### DIFF
--- a/apps/parkback/app/_lib/InstallHintBanner.tsx
+++ b/apps/parkback/app/_lib/InstallHintBanner.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY_HOME = "parkback_install_hint_dismissed";
+const STORAGE_KEY_FIND = "parkback_install_hint_find_dismissed";
+
+const GOLD = "#D4AF37";
+const GOLD_DIM = "#8a6f1f";
+const PAPER = "#f5f1e6";
+const MUTED = "#9a9588";
+
+type Platform = "ios" | "android" | "desktop" | "unknown";
+
+function detectPlatform(): Platform {
+  if (typeof navigator === "undefined") return "unknown";
+  const ua = navigator.userAgent;
+  const isIOS =
+    /iPad|iPhone|iPod/.test(ua) ||
+    ((navigator as Navigator & { platform: string }).platform === "MacIntel" &&
+      ((navigator as Navigator & { maxTouchPoints?: number }).maxTouchPoints || 0) > 1);
+  if (isIOS) return "ios";
+  if (/Android/i.test(ua)) return "android";
+  // Treat anything with a normal mouse-based browser as desktop.
+  if (typeof window !== "undefined" && window.matchMedia?.("(pointer: fine)").matches) return "desktop";
+  return "unknown";
+}
+
+function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  if (window.matchMedia?.("(display-mode: standalone)").matches) return true;
+  return Boolean((window.navigator as Navigator & { standalone?: boolean }).standalone);
+}
+
+const HOME_COPY: Record<Platform, string> = {
+  ios:
+    "Add ParkBack to your home screen for one-tap access. Tap the Share button below, then “Add to Home Screen.” No app store needed — it’s free, no signup, works offline.",
+  android:
+    "Add ParkBack to your home screen for one-tap access. Tap the three-dot menu (top right), then “Install app” or “Add to Home Screen.” No app store needed — it’s free, no signup, works offline.",
+  desktop:
+    "ParkBack works on any device. Tap the install icon in your address bar to add it as an app. Free, no signup, works offline.",
+  unknown:
+    "Add ParkBack to your home screen for one-tap access. No app store needed — it’s free, no signup, works offline.",
+};
+
+const FIND_COPY: Record<Platform, string> = {
+  ios:
+    "Like what you see? Add ParkBack to your home screen and never lose your own car. Tap the Share button below, then “Add to Home Screen.”",
+  android:
+    "Like what you see? Add ParkBack to your home screen and never lose your own car. Tap the three-dot menu (top right), then “Install app” or “Add to Home Screen.”",
+  desktop:
+    "Like what you see? ParkBack works on any device — tap the install icon in your address bar to add it as an app.",
+  unknown:
+    "Like what you see? Add ParkBack to your home screen and never lose your own car. No app store needed.",
+};
+
+export function InstallHintBanner({ where }: { where: "home" | "find" }) {
+  const [show, setShow] = useState(false);
+  const [platform, setPlatform] = useState<Platform>("unknown");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (isStandalone()) return;
+    const key = where === "find" ? STORAGE_KEY_FIND : STORAGE_KEY_HOME;
+    try {
+      if (window.localStorage.getItem(key) === "1") return;
+    } catch {
+      return;
+    }
+    setPlatform(detectPlatform());
+    setShow(true);
+  }, [where]);
+
+  if (!show) return null;
+
+  const copy = where === "find" ? FIND_COPY[platform] : HOME_COPY[platform];
+
+  const dismiss = () => {
+    setShow(false);
+    try {
+      const key = where === "find" ? STORAGE_KEY_FIND : STORAGE_KEY_HOME;
+      window.localStorage.setItem(key, "1");
+    } catch {
+      // localStorage might be disabled — silently ignore.
+    }
+  };
+
+  return (
+    <div role="region" aria-label="Install ParkBack" style={bannerStyle}>
+      <div style={textStyle}>{copy}</div>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss install hint"
+        style={dismissBtnStyle}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+const bannerStyle: React.CSSProperties = {
+  width: "100%",
+  maxWidth: 520,
+  marginTop: 8,
+  marginBottom: 4,
+  padding: "10px 14px 10px 16px",
+  display: "flex",
+  alignItems: "flex-start",
+  gap: 10,
+  borderRadius: 12,
+  border: `1px solid ${GOLD_DIM}`,
+  background:
+    "linear-gradient(180deg, rgba(212, 175, 55, 0.10) 0%, rgba(212, 175, 55, 0.04) 100%)",
+  color: PAPER,
+  fontSize: 13,
+  lineHeight: 1.45,
+  textAlign: "left",
+  boxShadow: "0 4px 14px rgba(0,0,0,0.35)",
+};
+
+const textStyle: React.CSSProperties = {
+  flex: 1,
+  color: PAPER,
+};
+
+const dismissBtnStyle: React.CSSProperties = {
+  flex: "0 0 auto",
+  width: 28,
+  height: 28,
+  background: "transparent",
+  color: MUTED,
+  border: "none",
+  borderRadius: 6,
+  fontSize: 22,
+  lineHeight: 1,
+  cursor: "pointer",
+  padding: 0,
+  marginTop: -2,
+};
+
+// First-visit one-line explainer shown under the Drop pin button. Auto-hides
+// once the user successfully drops a pin (the parent component is responsible
+// for not rendering this when a pin exists; this helper just persists
+// "I've dismissed it forever" once explicitly dismissed or once a pin has
+// been dropped).
+const STORAGE_KEY_EXPLAINER = "parkback_first_visit_explainer_dismissed";
+
+export function FirstVisitExplainer() {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      if (window.localStorage.getItem(STORAGE_KEY_EXPLAINER) === "1") return;
+    } catch {
+      return;
+    }
+    setShow(true);
+  }, []);
+
+  if (!show) return null;
+  return (
+    <div style={explainerStyle}>
+      Tap when you park. Come back, tap again, find your car. That’s it.
+    </div>
+  );
+}
+
+export function dismissFirstVisitExplainer() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY_EXPLAINER, "1");
+  } catch {
+    // ignore
+  }
+}
+
+const explainerStyle: React.CSSProperties = {
+  marginTop: 14,
+  color: GOLD,
+  fontSize: 14,
+  fontWeight: 500,
+  letterSpacing: "0.01em",
+  maxWidth: 320,
+  textAlign: "center",
+  lineHeight: 1.4,
+};

--- a/apps/parkback/app/find/page.tsx
+++ b/apps/parkback/app/find/page.tsx
@@ -16,6 +16,7 @@ import { track } from "../_lib/analytics";
 import { recipientHomeUrl } from "../_lib/share";
 import { HiveFooter } from "../_lib/HiveFooter";
 import { HexButton } from "../_lib/HexButton";
+import { InstallHintBanner } from "../_lib/InstallHintBanner";
 
 const GOLD = "#D4AF37";
 const GOLD_DIM = "#8a6f1f";
@@ -135,6 +136,8 @@ function FindInner() {
 
   return (
     <main style={pageStyle}>
+      <InstallHintBanner where="find" />
+
       <header style={sharedHeaderStyle}>
         <div style={brandStyle}>ParkBack</div>
         <div style={sharedTitleStyle}>Someone shared their parking spot with you.</div>

--- a/apps/parkback/app/page.tsx
+++ b/apps/parkback/app/page.tsx
@@ -14,6 +14,7 @@ import { track } from "./_lib/analytics";
 import { buildShareUrl } from "./_lib/share";
 import { HiveFooter } from "./_lib/HiveFooter";
 import { HexButton } from "./_lib/HexButton";
+import { InstallHintBanner, FirstVisitExplainer, dismissFirstVisitExplainer } from "./_lib/InstallHintBanner";
 
 const STORAGE_KEY = "parkback_pin_v1";
 const A2HS_DISMISSED_KEY = "parkback_a2hs_dismissed_v1";
@@ -234,6 +235,7 @@ export default function ParkBackPage() {
         setPhotoSkipped(false);
         setVoiceSkipped(false);
         track("pin_dropped", { has_altitude: draft.altitude !== null });
+        dismissFirstVisitExplainer();
 
         // Show "Add to Home Screen" hint once on iOS Safari, only if not standalone yet.
         if (
@@ -437,6 +439,8 @@ export default function ParkBackPage() {
   if (!pin) {
     return (
       <main style={pageStyle}>
+        <InstallHintBanner where="home" />
+
         <header style={headerStyle}>
           <div style={brandStyle}>ParkBack</div>
           <div style={taglineStyle}>Find your car. No accounts. No cloud.</div>
@@ -455,6 +459,8 @@ export default function ParkBackPage() {
         >
           {perm === "requesting" ? "Locating…" : "Drop pin"}
         </HexButton>
+
+        <FirstVisitExplainer />
 
         <div style={hintStyle}>
           {perm === "requesting"

--- a/docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md
+++ b/docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md
@@ -41,6 +41,14 @@
 | `robots.txt` and `sitemap.xml` in `public/`. | MANDATORY | Crawlers either ignore the engine entirely or index dev/preview surfaces. |
 | JSON-LD `SoftwareApplication` schema in the root layout. | MANDATORY | Google's rich-result blocks won't fire; the engine doesn't show up in the right SERP cards. |
 
+## FIRST-USE ONBOARDING
+
+| Item | Status | Failure mode if skipped |
+|---|---|---|
+| PWA install hint banner with platform-specific instructions on first visit. Detect iOS Safari, Android Chrome, desktop, unknown — and show the right install steps for each. Dismissable via × button, persisted in `localStorage`. | MANDATORY | Users never realise they can install the engine to their home screen — engagement and return-visit rate halve. |
+| One-line explainer for the primary action on first visit, dismissed permanently after the first successful primary action. | MANDATORY | First-time users hit the screen, don't know what the giant button does, bounce. |
+| Add-to-Home-Screen prompt after first successful primary action. | MANDATORY *for engines with a clear primary action* | The teachable moment for "install this" is right after the user has felt the value once — miss it and they may never return. |
+
 ## VIRAL LOOP
 
 | Item | Status | Failure mode if skipped |


### PR DESCRIPTION
## Summary

Two first-visit onboarding nudges in ParkBack, plus a new MANDATORY category in the canonical engine finalization checklist.

## What ships

### `InstallHintBanner` — platform-aware install nudge

`apps/parkback/app/_lib/InstallHintBanner.tsx` (new)

- Detects platform via `userAgent` + `matchMedia('(pointer: fine)')` → `ios | android | desktop | unknown`
- Renders the right copy for each:

| Platform | Copy |
|---|---|
| iOS | "Tap the Share button below, then 'Add to Home Screen.'" |
| Android | "Tap the three-dot menu (top right), then 'Install app' or 'Add to Home Screen.'" |
| Desktop | "Tap the install icon in your address bar to add it as an app." |
| Unknown | Generic "Add ParkBack to your home screen for one-tap access." |

- Two variants via `where` prop:
  - `where="home"` — standard "Add ParkBack to your home screen for one-tap access. No app store needed — it's free, no signup, works offline."
  - `where="find"` — recipient-flavoured "Like what you see? Add ParkBack to your home screen and never lose your own car." Same platform-specific install steps appended. **The viral loop continues into adoption.**

- Dismissable via × button. Persisted forever in `localStorage` under `parkback_install_hint_dismissed` (home) and `parkback_install_hint_find_dismissed` (find).
- **Skipped entirely if already running in standalone mode** (PWA installed) — installed users don't need an install nudge.

### `FirstVisitExplainer` — the one-line "what does this do"

Renders a single line under the Drop pin button:

> Tap when you park. Come back, tap again, find your car. That's it.

- Persisted in `localStorage` under `parkback_first_visit_explainer_dismissed`
- **Auto-dismissed when the user drops their first pin** — the existing `dropPin` handler now calls `dismissFirstVisitExplainer()` right inside the `track("pin_dropped", …)` callsite. The teachable moment dies the moment the user has felt it.

### Wired into both routes

| Route | Banner | Explainer |
|---|---|---|
| `/` (page.tsx) | `<InstallHintBanner where="home" />` above the brand header | `<FirstVisitExplainer />` directly under the Drop pin HexButton |
| `/find` (find/page.tsx) | `<InstallHintBanner where="find" />` above the shared-spot header | n/a (no primary action on the shared view) |

### Canonical checklist updated

`docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md` gets a new **FIRST-USE ONBOARDING** MANDATORY category between SEO and VIRAL LOOP, with three items, each carrying its failure mode:

1. PWA install hint banner with platform-specific instructions on first visit
2. One-line explainer for the primary action on first visit, dismissed after first success
3. Add-to-Home-Screen prompt after first successful primary action (already in the checklist under "Adoption Amplifiers" — included again here as a complete onboarding flow checkpoint)

## i18n note (read this)

The brief asked that the new strings be translated into all locale files via the i18n PR. **The i18n PR has not landed yet** — it's been blocked on a missing `ANTHROPIC_API_KEY` in the Codespace env (per your "do not commit hand-translated guesses" rule). New strings ship as English-only for now; once `ANTHROPIC_API_KEY` lands and the i18n PR runs, the same generate-from-canonical-source flow will pick these strings up and translate them. They fall back to English in the meantime, which matches the rest of the engine — **not a regression, just a shared open blocker**.

## Test plan

- [x] `npx next build` — clean, 5 routes prerendered
- [ ] Phone QA: confirm iOS / Android / desktop banners render the right copy on respective devices
- [ ] Verify dismissals persist across reloads (localStorage)
- [ ] Verify the explainer auto-dismisses after the first pin drop and never re-appears

## Auto-merge

Will mark ready and merge once CI is green per the standing rule.

https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv)_