### PR TITLE
feat(parkback): positioning block highlighting what makes ParkBack different

### DIFF
--- a/apps/parkback/app/page.tsx
+++ b/apps/parkback/app/page.tsx
@@ -460,6 +460,15 @@ export default function ParkBackPage() {
           {perm === "requesting" ? "Locating…" : "Drop pin"}
         </HexButton>
 
+        <div style={positioningBlockStyle}>
+          <div style={positioningLine1Style}>
+            No app store. No login. No subscription. No ads. No tracking. No signal needed.
+          </div>
+          <div style={positioningLine2Style}>
+            The parking app that should have existed years ago.
+          </div>
+        </div>
+
         <FirstVisitExplainer />
 
         <div style={hintStyle}>
@@ -805,6 +814,34 @@ const actionsRowStyle: React.CSSProperties = {
   maxWidth: 360,
   justifyContent: "space-between",
   flexWrap: "wrap",
+};
+
+const positioningBlockStyle: React.CSSProperties = {
+  marginTop: 18,
+  marginBottom: 6,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 4,
+  maxWidth: 380,
+  padding: "0 12px",
+  textAlign: "center",
+  lineHeight: 1.5,
+};
+
+const positioningLine1Style: React.CSSProperties = {
+  color: "#B89730",
+  fontSize: 12,
+  fontWeight: 500,
+  letterSpacing: "0.01em",
+};
+
+const positioningLine2Style: React.CSSProperties = {
+  color: "#B89730",
+  fontSize: 12,
+  fontStyle: "italic",
+  fontWeight: 400,
+  letterSpacing: "0.01em",
 };
 
 const a2hsStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary

Adds a permanent two-line positioning block between the Drop Pin button and the FirstVisitExplainer. Visible on every visit, not just first — it's part of the page identity, not an onboarding nudge.

## Lines

| | Copy |
|---|---|
| Line 1 | "No app store. No login. No subscription. No ads. No tracking. No signal needed." |
| Line 2 | "The parking app that should have existed years ago." |

## Visual treatment

- Color: `#B89730` (dimmer gold) — matches the Hive palette but stays quieter than the action button's `#D4AF37`.
- Size 12 (smaller than the 14 px FirstVisitExplainer; smaller still than the 26 px Drop Pin label).
- Line 1 weight 500 regular — reads as the manifesto.
- Line 2 weight 400 italic — reads as a closing thought / tagline.
- Centered, `max-width: 380`, `line-height: 1.5`, 18 px breathing room above, 6 px below.

## Spec compliance

- **No competitor names anywhere** ✓
- **No "unlike"** or comparative phrasing ✓
- Contrast is **implicit through what ParkBack is**, never through what others aren't ✓
- **Visible permanently**, part of page identity, not just first visit ✓

## i18n

Strings sit inline in JSX, identical to the rest of ParkBack's hardcoded English. The i18n catch-up will pick them up alongside the dead-zone copy from #67 and other queued strings.

## Auto-merge

Will mark ready and merge once CI is green per the standing rule.

https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv)_