### PR TITLE
feat(parkback): rename action labels to user-voice plain language

### DIFF
--- a/apps/parkback/app/_lib/InstallHintBanner.tsx
+++ b/apps/parkback/app/_lib/InstallHintBanner.tsx
@@ -37,7 +37,7 @@ function isStandalone(): boolean {
 // for every platform — iOS Safari and Android Chrome both surface their own
 // install affordances when the manifest is present.
 const HOME_BANNER =
-  "Add ParkBack to your home screen. Works in any dead zone. No cell signal, wifi, or app store needed. Free, no signup. Your pin, photo, and voice memo are saved on your phone — no signal required to find your car.";
+  "Add ParkBack to your home screen. Works in any dead zone. No cell signal, wifi, or app store needed. Free, no signup. Your pin, photo, and voice memo are saved on your phone — no cell or wifi signal required to find your car.";
 
 // Recipient-flavoured banner. Same dead-zone framing as the home banner, but
 // addressed to someone who arrived via a shared spot link — they've already
@@ -152,7 +152,7 @@ export function FirstVisitExplainer() {
   if (!show) return null;
   return (
     <div style={explainerStyle}>
-      Tap when you park. Come back, tap again, walk straight to your car. Works in underground garages with zero signal. Your phone’s GPS does the work.
+      Tap when you park. Come back, tap again, walk straight to your car. Works in underground garages with zero cell or wifi signal. Your phone’s GPS does the work.
     </div>
   );
 }

--- a/apps/parkback/app/page.tsx
+++ b/apps/parkback/app/page.tsx
@@ -148,7 +148,7 @@ export default function ParkBackPage() {
   const showToast = useCallback((msg: string) => {
     setToast(msg);
     if (toastTimerRef.current !== null) window.clearTimeout(toastTimerRef.current);
-    toastTimerRef.current = window.setTimeout(() => setToast(null), 2200);
+    toastTimerRef.current = window.setTimeout(() => setToast(null), 4500);
   }, []);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -236,6 +236,7 @@ export default function ParkBackPage() {
         setVoiceSkipped(false);
         track("pin_dropped", { has_altitude: draft.altitude !== null });
         dismissFirstVisitExplainer();
+        showToast("Got it. Walk wherever. Come back when you need your car.");
 
         // Show "Add to Home Screen" hint once on iOS Safari, only if not standalone yet.
         if (
@@ -455,9 +456,9 @@ export default function ParkBackPage() {
           size="lg"
           onClick={dropPin}
           busy={perm === "requesting"}
-          ariaLabel="Drop pin where I'm parked"
+          ariaLabel="I'm parked, save this spot"
         >
-          {perm === "requesting" ? "Locating…" : "Drop pin"}
+          {perm === "requesting" ? "Locating…" : "I’m parked"}
         </HexButton>
 
         <div style={positioningBlockStyle}>
@@ -474,7 +475,7 @@ export default function ParkBackPage() {
         <div style={hintStyle}>
           {perm === "requesting"
             ? "Hold still. High-accuracy GPS takes a moment."
-            : "Tap when you've parked. Works offline once installed."}
+            : "Tap when you've parked. Works offline."}
         </div>
 
         <HiveFooter />
@@ -599,8 +600,8 @@ export default function ParkBackPage() {
 
       <div style={actionsRowStyle}>
         <HexButton variant="primary" size="md" onClick={handleNavigate} ariaLabel="Navigate to my car">Navigate</HexButton>
-        <HexButton variant="ghost" size="md" onClick={handleShare} ariaLabel="Share parking spot">Share</HexButton>
-        <HexButton variant="ghost" size="md" onClick={handleClear} ariaLabel="Clear saved pin">Clear</HexButton>
+        <HexButton variant="ghost" size="md" onClick={handleShare} ariaLabel="Send my parking spot to someone">Send</HexButton>
+        <HexButton variant="ghost" size="md" onClick={handleClear} ariaLabel="Forget this spot">Forget</HexButton>
       </div>
 
       {showA2HS ? (

--- a/docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md
+++ b/docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md
@@ -29,6 +29,7 @@
 | All UI strings externalized to per-locale JSON files under `apps/<engine>/locales/`. | MANDATORY | English-only ship — alienates >70% of the world. Any future translation requires touching every component. |
 | Languages match UD Converter's free-tier default set. | MANDATORY | Engine uses a different language list than the rest of the Hive — translation gaps users notice. |
 | `navigator.language` detection at page load with English fallback. | MANDATORY | Engine ignores the browser locale even when a translation exists; the user never sees their language. |
+| All user-facing button labels and headings must use plain-language user-voice phrasing, not app-voice technical shorthand. Avoid metaphors that don't translate (e.g. "drop pin"). Reviewers ask: would a non-tech-fluent user in any language understand this label without explanation? | MANDATORY | Translation produces literal-but-meaningless strings; even native English speakers stumble on idiomatic UI verbs. |
 
 ## SEO
 
@@ -48,6 +49,7 @@
 | PWA install hint banner with platform-specific instructions on first visit. Detect iOS Safari, Android Chrome, desktop, unknown — and show the right install steps for each. Dismissable via × button, persisted in `localStorage`. | MANDATORY | Users never realise they can install the engine to their home screen — engagement and return-visit rate halve. |
 | One-line explainer for the primary action on first visit, dismissed permanently after the first successful primary action. | MANDATORY | First-time users hit the screen, don't know what the giant button does, bounce. |
 | Add-to-Home-Screen prompt after first successful primary action. | MANDATORY *for engines with a clear primary action* | The teachable moment for "install this" is right after the user has felt the value once — miss it and they may never return. |
+| When an engine claims offline capability, the copy must specifically name "cell" and "wifi" rather than the ambiguous "signal" or "internet." Users misinterpret "no signal" as "still needs wifi"; spelling both out closes the gap. | MANDATORY *for engines that claim offline capability* | Users skip installing because they assume offline still requires wifi at home. The promise is undermined by its own ambiguity. |
 
 ## VIRAL LOOP
 


### PR DESCRIPTION
## Summary

Renames every primary action label in ParkBack from app-voice technical shorthand to user-voice plain language, plus removes hedging conditional qualifiers from the action area, plus codifies both rules in the canonical checklist. **Must merge before tomorrow's i18n catch-up so the new English source strings are what gets translated.**

## Visible button labels

| Old | New |
|---|---|
| Drop pin | **I'm parked** |
| Share | **Send** |
| Clear | **Forget** |
| Navigate | (unchanged — already plain user-voice) |
| Take photo | (unchanged) |
| Record | (unchanged) |

The hex md buttons (110×95 at 14 px) wrap awkwardly with the long phrasing. Visible labels are kept short and confident; **the full user-voice phrase from the brief is preserved in `aria-label`** for screen readers and voice control:

- `aria-label="I'm parked, save this spot"`
- `aria-label="Send my parking spot to someone"`
- `aria-label="Forget this spot"`

If you want the long phrases visible too, one-line follow-up to lift the action row off `md` size onto a wider variant.

## Confirmation toast on first successful pin drop

> "Got it. Walk wherever. Come back when you need your car."

Bumped the toast auto-dismiss from 2200 ms to 4500 ms so the longer message reads cleanly.

## Hint copy de-hedged

| Old | New |
|---|---|
| "Tap when you've parked. Works offline once installed." | "Tap when you've parked. Works offline." |

`once installed` added cognitive load with no value — the install state is communicated through `InstallHintBanner` separately. The action area should sound like a confident statement, not a list of preconditions.

## Offline-capability copy: cell + wifi specificity

Users misinterpret bare "no signal" as "still needs wifi". Naming both closes the gap.

| Where | Old | New |
|---|---|---|
| `FirstVisitExplainer` | "with zero signal" | "with zero cell or wifi signal" |
| `HOME_BANNER` trailing | "no signal required" | "no cell or wifi signal required" |

## Canonical checklist (`docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md`)

Two new MANDATORY items:

1. **INTERNATIONALIZATION → plain-language labels**: "All user-facing button labels and headings must use plain-language user-voice phrasing, not app-voice technical shorthand. Avoid metaphors that don't translate (e.g. 'drop pin'). Reviewers should ask: would a non-tech-fluent user in any language understand this label without explanation?"
2. **FIRST-USE ONBOARDING → cell+wifi specificity**: "When an engine claims offline capability, the copy must specifically name 'cell' and 'wifi' rather than the ambiguous 'signal' or 'internet.' Users misinterpret 'no signal' as 'still needs wifi'; spelling both out closes the gap."

## i18n note

This PR must merge before tomorrow's i18n catch-up. The new English source strings (button labels, aria-labels, toast, hint, FirstVisitExplainer, HOME_BANNER) will then be the canonical input to translation.

## Auto-merge

Will mark ready and merge once CI is green per the standing rule.

https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpJu6EgvzBVGSEugKxCnsv)_