### PR TITLE
fix(parkback): iOS Safari render regression — restore home screen elements

### DIFF
--- a/apps/parkback/app/_lib/ServiceWorkerRegistrar.tsx
+++ b/apps/parkback/app/_lib/ServiceWorkerRegistrar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Must match CACHE_NAME in /public/sw.js. Bump both together when the SW
+// changes in a way that should force a one-time client reload.
+const ACTIVE_CACHE = "parkback-shell-v3";
+const RELOAD_GATE_KEY = `parkback_sw_reloaded_for_${ACTIVE_CACHE}`;
+
+// Renders nothing. Subscribes to "SW_ACTIVATED" messages from the service
+// worker; when a new SW takes over a client that's currently displaying a
+// stale precached app shell, this triggers a one-time reload so the user
+// sees the fresh build immediately. SessionStorage gates against any
+// possibility of a reload loop.
+export function ServiceWorkerRegistrar() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator)) return;
+
+    const onMessage = (e: MessageEvent) => {
+      if (e.data?.type !== "SW_ACTIVATED") return;
+      if (e.data?.cache !== ACTIVE_CACHE) return;
+      try {
+        if (window.sessionStorage.getItem(RELOAD_GATE_KEY) === "1") return;
+        window.sessionStorage.setItem(RELOAD_GATE_KEY, "1");
+      } catch {
+        // sessionStorage disabled — skip the reload rather than risk a loop.
+        return;
+      }
+      window.location.reload();
+    };
+
+    navigator.serviceWorker.addEventListener("message", onMessage);
+    return () => navigator.serviceWorker.removeEventListener("message", onMessage);
+  }, []);
+
+  return null;
+}

--- a/apps/parkback/app/layout.tsx
+++ b/apps/parkback/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import Script from "next/script";
+import { ServiceWorkerRegistrar } from "./_lib/ServiceWorkerRegistrar";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://parkback.hive.baby";
 const PLAUSIBLE_DOMAIN = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN || "parkback.hive.baby";
@@ -96,6 +97,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         }}
       >
         {children}
+        <ServiceWorkerRegistrar />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationLd) }}

--- a/apps/parkback/public/sw.js
+++ b/apps/parkback/public/sw.js
@@ -1,7 +1,12 @@
 // ParkBack service worker
 // Caches the app shell so the page loads in underground garages with no signal.
 
-const CACHE_NAME = "parkback-shell-v2";
+// Cache name bumped from v2 → v3 to force re-install on every existing client
+// and clear stale precached "/" HTML from the PR #66–#70 era. Bump again
+// (v3 → v4 etc) any time a future change might leave users stuck on a stale
+// app-shell snapshot.
+const CACHE_NAME = "parkback-shell-v3";
+const STALE_CACHE_NAMES = ["parkback-shell-v2"];
 const SHELL_URLS = [
   "/",
   "/manifest.json",
@@ -22,13 +27,28 @@ self.addEventListener("install", (event) => {
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
+    (async () => {
+      // Explicit cleanup of known-stale caches first (defensive — the generic
+      // sweep below would also catch these, but naming them makes the intent
+      // obvious and survives a future rename of CACHE_NAME).
+      await Promise.all(
+        STALE_CACHE_NAMES.map((n) => caches.delete(n).catch(() => {}))
+      );
+      // Generic sweep of anything else not matching current.
+      const keys = await caches.keys();
+      await Promise.all(
         keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k))
-      )
-    )
+      );
+      await self.clients.claim();
+      // Tell every open client (Safari tabs + home-screen PWA windows) that a
+      // new SW is now active, so anyone holding a stale precached "/" from a
+      // prior build can reload to the fresh HTML/JS without a manual refresh.
+      const clients = await self.clients.matchAll({ type: "window" });
+      for (const c of clients) {
+        c.postMessage({ type: "SW_ACTIVATED", cache: CACHE_NAME });
+      }
+    })()
   );
-  self.clients.claim();
 });
 
 self.addEventListener("fetch", (event) => {


### PR DESCRIPTION
## Symptom (still reported by Sonny after PR #72 merged)

`parkback.hive.baby` on iPhone Safari renders only a compass pointer. Missing: install hint banner, first-visit explainer, Drop Pin button, positioning block, footer. Persists after Sonny cleared all Safari history and website data.

## What's actually wrong

PR #72 reverted the broken JS from PR #70, and a headless WebKit + iPhone 14 viewport probe of production confirms the live HTML/JS bundle is healthy — both the no-pin home screen (banner, brand, \"I'm parked\", positioning, explainer, footer) and the pin-set state (elapsed, compass, distance, Navigate/Send/Forget, footer) render correctly. **The bundle on the wire is fine.**

The bug is **client-side cache state** on devices that visited during the broken PR #70 window:

1. `apps/parkback/public/sw.js` was last modified in PR #58 — its bytes have not changed since. Browsers compare SW scripts byte-for-byte to decide whether to install an update. Because no commit since #58 has touched the SW, **no SW update has ever been triggered on existing clients**. Whatever SW was registered when a user first visited is still active.
2. The SW's install handler precaches \`/\` (`SHELL_URLS = [\"/\", ...]`). On Sonny's iPhone, that precache happened during the PR #70 era and captured the broken HTML, which references chunk hashes that no longer exist on the server.
3. The \`/\` fetch handler is network-first, which *should* serve fresh HTML on every online visit. But on any flaky-connectivity moment (cellular handoff, garage signal loss, brief packet loss before retry) the \`.catch()\` branch falls back to \`caches.match(\"/\")\` and returns the stale precached broken shell.
4. Sonny installed ParkBack to his iPhone home screen yesterday during testing. iOS Safari's \"Clear History and Website Data\" does **not** unregister service workers for sites added to the home screen — the PWA has a separate WebKit storage scope. That's why clearing Safari data didn't help.

## Fix

Three small changes; ~66 lines added, 6 removed:

* **`apps/parkback/public/sw.js`**: bump \`CACHE_NAME\` from \`\"parkback-shell-v2\"\` → \`\"parkback-shell-v3\"\`. Because this changes the SW script bytes, every existing client (Sonny's home-screen PWA included) will now detect an update on its next load, install the new SW, and run its activate handler.
* **`sw.js` activate handler**: explicitly delete \`\"parkback-shell-v2\"\` (defensive — the existing generic sweep would also catch it) and then post \`{type:\"SW_ACTIVATED\", cache:\"parkback-shell-v3\"}\` to every open window client via \`clients.matchAll() + postMessage\`.
* **New \`apps/parkback/app/_lib/ServiceWorkerRegistrar.tsx\`**: tiny client component (renders \`null\`) that listens for the \`SW_ACTIVATED\` message and triggers a one-time \`location.reload()\`, gated by sessionStorage to make a reload loop impossible. Rendered once from the root layout, so it covers both \`/\` and \`/find\`.

**Net effect for Sonny:** open ParkBack from home screen → SW updates → activate handler wipes v2 cache + posts message → page auto-reloads once → fresh HTML/JS takes over. No manual cache clear, no need to remove and re-add the home-screen icon.

## Why not also revert / re-revert PRs #66–#69

Headless WebKit + iPhone 14 probes of the current production bundle (with both \`serviceWorkers: 'block'\` for clean state and \`serviceWorkers: 'allow'\` for the second-visit-with-SW case) render every element correctly. Banner, header, \"I'm parked\" button, positioning block, FirstVisitExplainer, footer — all present in the no-pin state. Elapsed, compass, distance, landmark, accuracy, Navigate/Send/Forget, footer — all present in the pin-set state. Only the cache-invalidation fix is needed.

## Headless attestation

Probed `https://parkback.hive.baby/` from Playwright + WebKit (Safari engine) using the iPhone 14 device profile (390×844). Two configurations:

| Configuration | Result |
|---|---|
| `serviceWorkers: 'block'`, empty localStorage | All no-pin elements render: install banner, ParkBack header + tagline, \"I'm parked\" button, positioning block (\"No app store. No login...\"), FirstVisitExplainer (\"Tap when you park...\"), hint, full footer |
| `serviceWorkers: 'allow'`, second visit with active SW | Same — all elements render after SW intercept |
| `serviceWorkers: 'block'`, pre-set pin in localStorage | Pin-set state renders fully: elapsed time, \"Locating you…\", landmark, accuracy, calibrating-compass note, photo prompt, voice prompt, Navigate / Send / Forget actions, footer |

Zero \`pageerror\`, zero failed requests, zero console errors in any configuration. The current production bundle is healthy.

**What I could NOT attest:** I could not headlessly reproduce the stuck \"compass-only\" state itself, because the underlying cause is a stale SW cache on a specific device. The fix is theory-driven from the SW + cache analysis above. **Sonny needs to verify on his actual iPhone after this deploys.**

## Merge gate — PAUSE

Per Sonny's explicit instruction on this hotfix: **do NOT auto-merge on green CI.** Wait for Sonny to verify the fix on his actual iPhone (open the home-screen ParkBack icon, confirm full home screen renders with banner + Drop Pin button + positioning block + explainer + footer). Once Sonny confirms, merge.

## Re-test plan after Sonny merges

1. Sonny opens ParkBack from his iPhone home screen.
2. Expected: a brief flash of stale content, then auto-reload, then the full no-pin home screen renders with all elements.
3. If still broken: long-press the home-screen icon, remove the app, re-add via Safari → home screen. (Manual escape hatch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)