### PR TITLE
apps/parkback: ensure all three onboarding components present and wired

### DIFF
--- a/apps/parkback/app/_lib/InstallHintBanner.tsx
+++ b/apps/parkback/app/_lib/InstallHintBanner.tsx
@@ -5,8 +5,7 @@ import { useInstallPrompt } from "./useInstallPrompt";
 import { InstallCTA } from "./InstallCTA";
 import { strings } from "./strings";
 
-const STORAGE_KEY_HOME = "parkback_install_hint_dismissed";
-const STORAGE_KEY_FIND = "parkback_install_hint_find_dismissed";
+const STORAGE_KEY = "hive_install_hint_dismissed_parkback";
 
 const GOLD = "#D4AF37";
 const GOLD_DIM = "#8a6f1f";
@@ -37,9 +36,8 @@ export function InstallHintBanner({ where }: { where: "home" | "find" }) {
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (isStandalone()) return;
-    const key = where === "find" ? STORAGE_KEY_FIND : STORAGE_KEY_HOME;
     try {
-      if (window.localStorage.getItem(key) === "1") return;
+      if (window.localStorage.getItem(STORAGE_KEY) === "1") return;
     } catch {
       return;
     }
@@ -54,8 +52,7 @@ export function InstallHintBanner({ where }: { where: "home" | "find" }) {
     if (!installed) return;
     setShow(false);
     try {
-      window.localStorage.setItem(STORAGE_KEY_HOME, "1");
-      window.localStorage.setItem(STORAGE_KEY_FIND, "1");
+      window.localStorage.setItem(STORAGE_KEY, "1");
     } catch {
       // localStorage disabled — silently ignore.
     }
@@ -64,12 +61,11 @@ export function InstallHintBanner({ where }: { where: "home" | "find" }) {
   const dismiss = useCallback(() => {
     setShow(false);
     try {
-      const key = where === "find" ? STORAGE_KEY_FIND : STORAGE_KEY_HOME;
-      window.localStorage.setItem(key, "1");
+      window.localStorage.setItem(STORAGE_KEY, "1");
     } catch {
       // localStorage might be disabled — silently ignore.
     }
-  }, [where]);
+  }, []);
 
   if (!show) return null;
 
@@ -166,7 +162,7 @@ const dismissBtnStyle: React.CSSProperties = {
 // for not rendering this when a pin exists; this helper just persists
 // "I've dismissed it forever" once explicitly dismissed or once a pin has
 // been dropped).
-const STORAGE_KEY_EXPLAINER = "parkback_first_visit_explainer_dismissed";
+const STORAGE_KEY_EXPLAINER = "hive_first_visit_seen_parkback";
 
 export function FirstVisitExplainer() {
   const [show, setShow] = useState(false);

--- a/apps/parkback/app/page.tsx
+++ b/apps/parkback/app/page.tsx
@@ -18,7 +18,7 @@ import { InstallHintBanner, FirstVisitExplainer, dismissFirstVisitExplainer } fr
 import { HiveAHTSPrompt } from "./_lib/HiveAHTSPrompt";
 
 const STORAGE_KEY = "parkback_pin_v1";
-const A2HS_DISMISSED_KEY = "parkback_a2hs_dismissed_v1";
+const A2HS_DISMISSED_KEY = "hive_ahts_dismissed_parkback";
 
 function isStandalone(): boolean {
   if (typeof window === "undefined") return false;


### PR DESCRIPTION
## Findings (verification before HiveOps Phase 1)

All three onboarding components specced for ParkBack are **present and rendered**:

| Component | Definition | Rendered |
|---|---|---|
| InstallHintBanner | `apps/parkback/app/_lib/InstallHintBanner.tsx:33` | `app/page.tsx:434` (where=home), `app/find/page.tsx:139` (where=find) |
| FirstVisitExplainer | `apps/parkback/app/_lib/InstallHintBanner.tsx:171` | `app/page.tsx:464` |
| HiveAHTSPrompt | `apps/parkback/app/_lib/HiveAHTSPrompt.tsx:23` | `app/page.tsx:598` (gated behind `showA2HS`, set true after first pin drop on line 238) |

So PR #66 (banner + explainer) and an earlier change (AHTSPrompt) together cover all three. The AHTS prompt also satisfies the spec'd behaviour: triggered after first successful pin drop, modal with platform-specific instructions, primary "Add to home screen" button + persistent dismiss, "Add to home screen" framing throughout.

## Drift from spec — outcome D

All three components used non-canonical localStorage keys:

| Component | Was | Now |
|---|---|---|
| InstallHintBanner | `parkback_install_hint_dismissed` (+ `parkback_install_hint_find_dismissed`) | `hive_install_hint_dismissed_parkback` |
| FirstVisitExplainer | `parkback_first_visit_explainer_dismissed` | `hive_first_visit_seen_parkback` |
| HiveAHTSPrompt | `parkback_a2hs_dismissed_v1` | `hive_ahts_dismissed_parkback` |

The two install-hint keys collapsed into one because the canonical spec is a single key, and the existing behaviour already wrote both on `appinstalled` — they were effectively unified anyway.

## User-visible impact

Anyone who dismissed before this PR ships will re-see the onboarding once (their old `parkback_*` key no longer matches what the component reads). Acceptable: onboarding shipped <24h ago, very small dismissed population.

## Verification

- `npx tsc --noEmit` clean.
- Grep confirms zero remaining references to the old `parkback_*` keys; all three new `hive_*_parkback` keys present at the expected sites.