### PR TITLE
tools/hive-ops v0.1 — enforcement gate for engine finalization (28 MANDATORY rules)

### DIFF
--- a/.github/workflows/hive-ops.yml
+++ b/.github/workflows/hive-ops.yml
@@ -1,0 +1,106 @@
+name: HiveOps — engine launch checklist
+
+# Programmatic enforcer for docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md.
+#
+# Runs on:
+#   - PR to main: audits every engine under apps/ that has changed in the diff
+#   - workflow_dispatch with engine_slug input: audit one engine on demand
+#
+# Failures (verdict=fail) block the PR. Warns surface in the run summary
+# but do not block. See tools/hive-ops/README.md for the override schema
+# engines can use to register a tracked, time-bounded warn.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/**'
+      - 'tools/hive-ops/**'
+      - 'packages/hive-onboarding/**'
+      - '.github/workflows/hive-ops.yml'
+  workflow_dispatch:
+    inputs:
+      engine_slug:
+        description: "Engine slug under apps/ (e.g. parkback). Required."
+        required: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install hive-ops deps
+        working-directory: tools/hive-ops
+        run: npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+
+      - name: Determine engines to audit
+        id: targets
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "slugs=${{ github.event.inputs.engine_slug }}" >> "$GITHUB_OUTPUT"
+            echo "Manual run — auditing: ${{ github.event.inputs.engine_slug }}"
+            exit 0
+          fi
+          # PR run: changed files under apps/<slug>/ → unique slug list
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'apps/' 'tools/hive-ops/' 'packages/hive-onboarding/' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No engine changes in PR — skipping audit"
+            echo "slugs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Extract apps/<slug>/ unique slugs
+          SLUGS=$(echo "$CHANGED" | awk -F/ '$1=="apps" && NF>=2 {print $2}' | sort -u | xargs)
+          # If only tools/hive-ops or packages/hive-onboarding changed (no
+          # apps/), audit ParkBack as the reference canary so package
+          # regressions are caught.
+          if [ -z "$SLUGS" ]; then SLUGS="parkback"; fi
+          echo "slugs=$SLUGS" >> "$GITHUB_OUTPUT"
+          echo "PR changes → auditing: $SLUGS"
+
+      - name: Run HiveOps for each engine
+        if: steps.targets.outputs.slugs != ''
+        env:
+          SLUGS: ${{ steps.targets.outputs.slugs }}
+        run: |
+          set -uo pipefail
+          OVERALL=0
+          for slug in $SLUGS; do
+            echo "::group::HiveOps audit — $slug"
+            if npx --prefix tools/hive-ops tsx tools/hive-ops/cli.ts "$slug"; then
+              echo "::endgroup::"
+            else
+              CODE=$?
+              echo "::endgroup::"
+              if [ "$CODE" -eq 1 ]; then
+                echo "::error title=HiveOps verdict=fail for $slug::see audit output above"
+                OVERALL=1
+              else
+                echo "::error title=HiveOps tooling error for $slug::exit code $CODE"
+                OVERALL=2
+              fi
+            fi
+          done
+          # Append summary table
+          {
+            echo "## HiveOps run summary"
+            echo ""
+            echo "Engines audited: \`$SLUGS\`"
+            echo ""
+            echo "Overall: $([ "$OVERALL" -eq 0 ] && echo PASS || echo FAIL)"
+            echo ""
+            echo "_Override schema and rule reference: \`tools/hive-ops/README.md\`._"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $OVERALL

--- a/docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md
+++ b/docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md
@@ -10,6 +10,26 @@
 - When asked to build or finalize an engine, **search for each item before declaring it deferred** — much of the Hive infrastructure already exists; assume it does until you've looked.
 - The structured registry of who has shipped what lives in `engines.json` and `registry/*.md`. Update those at the same time you check items here.
 
+## Programmatic enforcement — HiveOps
+
+A subset of items in this checklist is enforced automatically by **HiveOps**
+(`tools/hive-ops/`). Run it locally before opening a PR:
+
+```sh
+tsx tools/hive-ops/cli.ts <engine-slug>
+```
+
+HiveOps v0.1 enforces 28 rules (26 MANDATORY, 2 RECOMMENDED) covering CORE
+BUILD, INTERNATIONALIZATION, SEO, FIRST-USE ONBOARDING, HIVE INTEGRATION,
+VISIBILITY SURFACES, DESIGN CONSISTENCY, ADOPTION AMPLIFIERS, and OPERATIONAL.
+The `.github/workflows/hive-ops.yml` workflow runs it on every PR — failing
+verdicts block merge.
+
+Items not yet enforced by HiveOps (real-device tests, network reachability
+checks, third-party integrations) remain manual review items. See
+`tools/hive-ops/README.md` for the full rule list, override schema, and the
+warn-mode mechanism for legitimately-deferred items.
+
 ---
 
 ## CORE BUILD

--- a/tools/hive-ops/README.md
+++ b/tools/hive-ops/README.md
@@ -1,0 +1,134 @@
+# @hive/ops
+
+Engine launch checklist enforcer. Programmatic gate for the MANDATORY items
+in [`docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md`](../../docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md).
+
+> **HiveOps is the launch-time enforcer. HiveFinalize is the schema validator.**
+> They are complementary: HiveOps reads the engine's filesystem and reports
+> what's missing for ship; HiveFinalize validates the engine's `ENGINE_GRAMMAR.md`
+> manifest against the canonical schema. PRs typically run both.
+
+## Quick start
+
+```sh
+tsx tools/hive-ops/cli.ts <engine-slug>
+# or:
+tsx tools/hive-ops/cli.ts <engine-slug> --json | jq .
+# from outside the hivebaby repo:
+tsx tools/hive-ops/cli.ts ud-converter --repo /path/to/universal-document
+```
+
+Exit codes:
+- **0** — verdict pass or warn
+- **1** — verdict fail
+- **2** — could not resolve engine root or other tooling error
+
+## Rules (28 total · 26 MANDATORY · 2 RECOMMENDED)
+
+| ID | Category | Title | Severity |
+|---|---|---|---|
+| H01 | CORE_BUILD | package.json present at engine root | MANDATORY |
+| H02 | CORE_BUILD | Next.js app router root layout present | MANDATORY |
+| H03 | CORE_BUILD | public/ directory present | MANDATORY |
+| H04 | INTERNATIONALIZATION | locales/ directory present | MANDATORY |
+| H05 | INTERNATIONALIZATION | all 7 canonical free-tier locales present (en, es, fr, ar, hi, zh, pt) | MANDATORY |
+| H06 | INTERNATIONALIZATION | navigator.language detection wired in strings loader | MANDATORY |
+| H07 | SEO | root layout exports metadata.title and metadata.description | MANDATORY |
+| H08 | SEO | public/og.png present | MANDATORY |
+| H09 | SEO | robots.txt present (public/ or app/robots.ts) | MANDATORY |
+| H10 | SEO | sitemap present (public/sitemap.xml or app/sitemap.ts) | MANDATORY |
+| H11 | FIRST_USE_ONBOARDING | PWA install hint banner present (HiveInstallHint or local equivalent) | MANDATORY |
+| H12 | FIRST_USE_ONBOARDING | first-visit explainer present (HiveFirstVisitExplainer or local equivalent) | MANDATORY |
+| H13 | HIVE_INTEGRATION | HIVE_HEADER_LOGO — public/hive-logo-full.png copied | MANDATORY |
+| H14 | HIVE_INTEGRATION | HIVE_FOOTER_SIGNATURE — "Made with ♥ in the Hive" rendered | MANDATORY |
+| H15 | HIVE_INTEGRATION | FAVICON_COMPLETE — full canonical favicon set in public/ | MANDATORY |
+| H16 | HIVE_INTEGRATION | THEME_COLOR_CANONICAL — #D4AF37 in metadata + manifest | MANDATORY |
+| H17 | HIVE_INTEGRATION | APPLE_WEB_APP_META — metadata.appleWebApp configured | MANDATORY |
+| H18 | HIVE_INTEGRATION | MANIFEST_COMPLETE — public/manifest.json has canonical fields | MANDATORY |
+| H19 | HIVE_INTEGRATION | ENGINE_GRAMMAR.md present in repo root with frontmatter | MANDATORY |
+| H20 | HIVE_INTEGRATION | service worker registrar present | MANDATORY |
+| H21 | VISIBILITY_SURFACES | engine entry present in hivebaby planet ENGINES array | MANDATORY |
+| H22 | DESIGN_CONSISTENCY | Hive gold #D4AF37 referenced in component / styles | MANDATORY |
+| H23 | DESIGN_CONSISTENCY | canonical dark ink #0a0a0a referenced | RECOMMENDED |
+| H24 | ADOPTION_AMPLIFIERS | manifest registered in layout (link rel="manifest") | MANDATORY |
+| H25 | ADOPTION_AMPLIFIERS | viewport meta with width=device-width set in layout | MANDATORY |
+| H26 | OPERATIONAL | .env.example or env_vars_required documented | RECOMMENDED |
+| H27 | OPERATIONAL | README.md present in engine root | MANDATORY |
+| H28 | OPERATIONAL | tsconfig.json with strict mode | MANDATORY |
+
+## Override schema — when a rule legitimately can't apply
+
+An engine can downgrade or waive a specific rule by adding a YAML block to
+its `ENGINE_GRAMMAR.md`:
+
+```markdown
+## Hive-Ops Overrides
+
+```yaml
+overrides:
+  - rule: H08
+    mode: warn
+    reason: "OG image generator broken; fix tracked in workflow X. Will be regenerated this week."
+    issue: https://github.com/saggarsonny-boop/hivebaby/issues/123
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-05-13   # 7 days default; 30 days max from `date`
+  - rule: H21
+    mode: waive
+    reason: "Internal-only engine; never appears on the planet."
+    issue: https://github.com/saggarsonny-boop/hivebaby/issues/124
+    reviewer: Sonny
+    date: 2026-05-06
+```
+```
+
+### Validation rules
+- `rule, mode, reason, issue, reviewer, date` are all REQUIRED for every entry
+- `mode` must be exactly `warn` or `waive`
+- `date` must be `YYYY-MM-DD`
+- `issue` must be a `https://github.com/<owner>/<repo>/issues/<n>` URL
+- For `mode: warn`:
+  - `warn_until` is REQUIRED (defaults to date + 7 days if omitted)
+  - `warn_until` must be ≤ 30 days after `date` (the hard ceiling)
+  - When `warn_until` is in the past, the warn lapses and the rule fires `fail` again with a note explaining the expiry
+- `mode: waive` ignores `warn_until`
+- Unknown rule IDs are reported as parse errors
+- Duplicate entries for the same rule are reported as parse errors
+- Rules marked `unwaivable: true` (currently H01) reject any override entry
+
+### Warn-mode philosophy
+
+Warn-mode exists for one reason: an engine that's mostly ready can ship while
+a single legitimate fix is in flight. It is **not** a long-term hiding place.
+The 30-day hard ceiling guarantees that today's warn becomes tomorrow's fail
+without anyone having to remember.
+
+If a rule needs more than 30 days of cover, that's not warn territory — it's
+either:
+- A `waive` (with documented reason and reviewer) if the rule legitimately
+  doesn't apply to this engine, OR
+- A change to the rule itself in `tools/hive-ops/rules.ts` if it's
+  systematically wrong.
+
+## CI integration
+
+`.github/workflows/hive-ops.yml` runs the CLI on every PR for changed engines
+under `apps/`. Failures block merge. Warns surface in the PR summary but
+don't block.
+
+## Local dev
+
+```sh
+cd tools/hive-ops
+npm install
+npx tsc --noEmit          # type-check
+npx tsx tests/rules.test.ts  # run smoke tests
+npx tsx cli.ts parkback --repo ../..   # audit a real engine
+```
+
+## Roadmap
+
+- **v0.2** — wire HiveFinalize manifest validation as part of the same run; surface as a single combined report.
+- **v0.2** — add network rules (Vercel deploy URL 200, Cloudflare CNAME, Stripe price IDs) — gated on the credential plumbing.
+- **v0.2** — Vercel env-var presence check via VERCEL_TOKEN.
+- **v0.3** — engine-class profiles (e.g. "static-html-only" engines exempt from the Next.js layout rules automatically).

--- a/tools/hive-ops/cli.ts
+++ b/tools/hive-ops/cli.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env tsx
+// HiveOps CLI.
+//
+// Usage:
+//   tsx tools/hive-ops/cli.ts <engine-slug> [--repo <path>] [--json]
+//
+// Examples:
+//   tsx tools/hive-ops/cli.ts parkback
+//   tsx tools/hive-ops/cli.ts ud-converter --repo ../universal-document
+//   tsx tools/hive-ops/cli.ts parkback --json | jq .
+//
+// Exit codes:
+//   0 — verdict pass or warn
+//   1 — verdict fail
+//   2 — could not resolve engine root or other tooling error
+
+import { resolve } from "node:path";
+import { runHiveOps, resolveEngineRoot } from "./runner.js";
+import { RULES, MANDATORY_COUNT, RECOMMENDED_COUNT } from "./rules.js";
+import type { EngineReport, RuleResult } from "./types.js";
+
+interface CliArgs {
+  slug: string;
+  repo: string;
+  json: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs | null {
+  const positional: string[] = [];
+  let repo = process.cwd();
+  let json = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--json") { json = true; continue; }
+    if (a === "--repo") { repo = resolve(argv[++i] ?? ""); continue; }
+    if (a === "-h" || a === "--help") return null;
+    positional.push(a);
+  }
+  if (positional.length !== 1) return null;
+  return { slug: positional[0], repo, json };
+}
+
+function usage(): string {
+  return [
+    "Usage: tsx tools/hive-ops/cli.ts <engine-slug> [--repo <path>] [--json]",
+    "",
+    `HiveOps v0.1 — ${MANDATORY_COUNT} MANDATORY + ${RECOMMENDED_COUNT} RECOMMENDED rules.`,
+    "Auditable engine launch checklist enforcer.",
+    "",
+    "Defaults:",
+    "  --repo  current working directory",
+  ].join("\n");
+}
+
+const STATUS_GLYPH: Record<RuleResult["status"], string> = {
+  pass: "✓",
+  warn: "!",
+  fail: "✗",
+  skip: "·",
+  override: "○",
+};
+
+function formatHuman(report: EngineReport): string {
+  const lines: string[] = [];
+  lines.push(`HiveOps audit — ${report.engineSlug}`);
+  lines.push(`  root: ${report.engineRoot}`);
+  lines.push(`  ${RULES.length} rules · ${MANDATORY_COUNT} MANDATORY · ${RECOMMENDED_COUNT} RECOMMENDED`);
+  lines.push("");
+
+  let cat = "";
+  for (const r of report.rules) {
+    if (r.category !== cat) {
+      lines.push(`-- ${r.category} --`);
+      cat = r.category;
+    }
+    const sev = r.severity === "MANDATORY" ? "M" : "r";
+    lines.push(`  ${STATUS_GLYPH[r.status]} ${r.id} [${sev}] ${r.title}`);
+    if (r.status !== "pass" && r.status !== "skip") {
+      lines.push(`      ${r.message}`);
+    }
+  }
+  lines.push("");
+
+  if (report.overrideParseErrors.length > 0) {
+    lines.push("OVERRIDE PARSE ERRORS:");
+    for (const err of report.overrideParseErrors) lines.push(`  ${err}`);
+    lines.push("");
+  }
+
+  if (report.warnModeRules.length > 0) {
+    lines.push("WARN-MODE RULES (expire on date — fix before then):");
+    for (const w of report.warnModeRules) {
+      lines.push(`  ${w.id} — warn_until ${w.warnUntil}`);
+    }
+    lines.push("");
+  }
+
+  const tally = report.rules.reduce<Record<string, number>>((acc, r) => {
+    acc[r.status] = (acc[r.status] ?? 0) + 1;
+    return acc;
+  }, {});
+  lines.push(`tally: pass=${tally.pass ?? 0} warn=${tally.warn ?? 0} fail=${tally.fail ?? 0} skip=${tally.skip ?? 0} override=${tally.override ?? 0}`);
+  lines.push("");
+  lines.push(`VERDICT: ${report.verdict.toUpperCase()}`);
+  return lines.join("\n");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args) {
+    console.error(usage());
+    process.exit(2);
+  }
+
+  const engineRoot = resolveEngineRoot(args.repo, args.slug);
+  if (!engineRoot) {
+    console.error(`error: could not find engine "${args.slug}" under ${args.repo}/apps/ or ${args.repo}/`);
+    process.exit(2);
+  }
+
+  const report = await runHiveOps(engineRoot);
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatHuman(report));
+  }
+
+  process.exit(report.verdict === "fail" ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("hive-ops crashed:", err);
+  process.exit(2);
+});

--- a/tools/hive-ops/overrides.ts
+++ b/tools/hive-ops/overrides.ts
@@ -1,0 +1,188 @@
+// HiveOps override loader. Reads the optional ## Hive-Ops Overrides
+// section from apps/<engine>/ENGINE_GRAMMAR.md and validates each entry
+// against the override schema.
+//
+// Override file shape (YAML inside the markdown body):
+//
+//   ## Hive-Ops Overrides
+//
+//   ```yaml
+//   overrides:
+//     - rule: H17
+//       mode: warn
+//       reason: "Engine intentionally has a one-word title."
+//       issue: https://github.com/saggarsonny-boop/hivebaby/issues/123
+//       reviewer: Sonny
+//       date: 2026-05-06
+//       warn_until: 2026-05-13
+//     - rule: H08
+//       mode: waive
+//       reason: "Static engine, no OG image needed."
+//       issue: https://github.com/saggarsonny-boop/hivebaby/issues/124
+//       reviewer: Sonny
+//       date: 2026-05-06
+//   ```
+//
+// Validation:
+//   - rule, mode, reason, issue, reviewer, date are all REQUIRED
+//   - mode must be "warn" or "waive"
+//   - date must be ISO YYYY-MM-DD
+//   - if mode=warn, warn_until is required AND must be within 30 days of date
+//   - issue must be a GitHub issue URL
+//   - rule must be a known H-rule ID
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+import YAML from "yaml";
+import type { OverrideEntry, ParsedOverrides } from "./types.js";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const GH_ISSUE = /^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/;
+const RULE_ID = /^H\d{2}$/;
+const MAX_WARN_DAYS = 30;
+const DEFAULT_WARN_DAYS = 7;
+
+export function loadOverrides(engineRoot: string, validRuleIds: ReadonlySet<string>): ParsedOverrides {
+  const path = join(engineRoot, "ENGINE_GRAMMAR.md");
+  if (!existsSync(path)) {
+    return { byRule: new Map(), parseErrors: [] };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    return {
+      byRule: new Map(),
+      parseErrors: [`could not read ${path}: ${err instanceof Error ? err.message : String(err)}`],
+    };
+  }
+
+  const parsed = matter(raw);
+  const body = parsed.content;
+  const block = extractOverridesYaml(body);
+  if (!block) return { byRule: new Map(), parseErrors: [] };
+
+  let yaml: unknown;
+  try {
+    yaml = YAML.parse(block);
+  } catch (err) {
+    return {
+      byRule: new Map(),
+      parseErrors: [`malformed YAML in ## Hive-Ops Overrides: ${err instanceof Error ? err.message : String(err)}`],
+    };
+  }
+
+  const errors: string[] = [];
+  const byRule = new Map<string, OverrideEntry>();
+
+  if (!yaml || typeof yaml !== "object") {
+    return { byRule, parseErrors: ["## Hive-Ops Overrides YAML did not parse as an object"] };
+  }
+  const root = yaml as { overrides?: unknown };
+  if (!Array.isArray(root.overrides)) {
+    return { byRule, parseErrors: ["## Hive-Ops Overrides YAML missing top-level `overrides:` list"] };
+  }
+
+  for (const [i, item] of root.overrides.entries()) {
+    if (!item || typeof item !== "object") {
+      errors.push(`overrides[${i}]: not an object`);
+      continue;
+    }
+    const e = item as Partial<OverrideEntry>;
+    if (typeof e.rule !== "string" || !RULE_ID.test(e.rule)) {
+      errors.push(`overrides[${i}]: rule must match /^H\\d{2}$/ (got ${JSON.stringify(e.rule)})`);
+      continue;
+    }
+    if (!validRuleIds.has(e.rule)) {
+      errors.push(`overrides[${i}]: rule ${e.rule} is not a known HiveOps rule ID`);
+      continue;
+    }
+    if (e.mode !== "warn" && e.mode !== "waive") {
+      errors.push(`overrides[${i}.${e.rule}]: mode must be "warn" or "waive" (got ${JSON.stringify(e.mode)})`);
+      continue;
+    }
+    if (typeof e.reason !== "string" || !e.reason.trim()) {
+      errors.push(`overrides[${i}.${e.rule}]: reason is required and must be non-empty`);
+      continue;
+    }
+    if (typeof e.issue !== "string" || !GH_ISSUE.test(e.issue)) {
+      errors.push(`overrides[${i}.${e.rule}]: issue must be a GitHub issue URL (got ${JSON.stringify(e.issue)})`);
+      continue;
+    }
+    if (typeof e.reviewer !== "string" || !e.reviewer.trim()) {
+      errors.push(`overrides[${i}.${e.rule}]: reviewer is required and must be non-empty`);
+      continue;
+    }
+    if (typeof e.date !== "string" || !ISO_DATE.test(e.date)) {
+      errors.push(`overrides[${i}.${e.rule}]: date must be YYYY-MM-DD (got ${JSON.stringify(e.date)})`);
+      continue;
+    }
+
+    let warn_until: string | undefined = e.warn_until;
+    if (e.mode === "warn") {
+      if (warn_until === undefined) {
+        // Default 7 days from `date` if unspecified.
+        warn_until = isoAddDays(e.date, DEFAULT_WARN_DAYS);
+      }
+      if (typeof warn_until !== "string" || !ISO_DATE.test(warn_until)) {
+        errors.push(`overrides[${i}.${e.rule}]: warn_until must be YYYY-MM-DD (got ${JSON.stringify(warn_until)})`);
+        continue;
+      }
+      const dateMs = Date.parse(e.date);
+      const warnMs = Date.parse(warn_until);
+      if (Number.isNaN(dateMs) || Number.isNaN(warnMs)) {
+        errors.push(`overrides[${i}.${e.rule}]: invalid date or warn_until value`);
+        continue;
+      }
+      const diffDays = (warnMs - dateMs) / (1000 * 60 * 60 * 24);
+      if (diffDays < 0) {
+        errors.push(`overrides[${i}.${e.rule}]: warn_until is before date`);
+        continue;
+      }
+      if (diffDays > MAX_WARN_DAYS) {
+        errors.push(
+          `overrides[${i}.${e.rule}]: warn_until ${warn_until} is more than ${MAX_WARN_DAYS} days after date ${e.date} (diff=${diffDays.toFixed(0)}d)`,
+        );
+        continue;
+      }
+    } else if (e.mode === "waive" && warn_until !== undefined) {
+      // waive mode does not use warn_until — flag but don't reject.
+      errors.push(`overrides[${i}.${e.rule}]: warn_until ignored for mode=waive`);
+      warn_until = undefined;
+    }
+
+    if (byRule.has(e.rule)) {
+      errors.push(`overrides[${i}.${e.rule}]: duplicate override entry for rule ${e.rule}`);
+      continue;
+    }
+
+    byRule.set(e.rule, {
+      rule: e.rule,
+      mode: e.mode,
+      reason: e.reason,
+      issue: e.issue,
+      reviewer: e.reviewer,
+      date: e.date,
+      warn_until,
+    });
+  }
+
+  return { byRule, parseErrors: errors };
+}
+
+/** Find the YAML fenced block immediately under ## Hive-Ops Overrides
+ *  (case-insensitive). Returns the raw YAML string or null. */
+function extractOverridesYaml(body: string): string | null {
+  const re = /^##\s+Hive-Ops Overrides\s*\n+\s*```ya?ml\s*\n([\s\S]*?)\n```/im;
+  const m = body.match(re);
+  return m ? m[1] : null;
+}
+
+function isoAddDays(iso: string, days: number): string {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return iso;
+  const next = new Date(ms + days * 24 * 60 * 60 * 1000);
+  return next.toISOString().slice(0, 10);
+}

--- a/tools/hive-ops/package-lock.json
+++ b/tools/hive-ops/package-lock.json
@@ -1,0 +1,717 @@
+{
+  "name": "@hive/ops",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@hive/ops",
+      "version": "0.1.0",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "yaml": "^2.3.4"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "tsx": "^4",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/tools/hive-ops/package.json
+++ b/tools/hive-ops/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@hive/ops",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Engine launch checklist enforcer. Programmatic gate for the MANDATORY items in docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md.",
+  "main": "cli.ts",
+  "scripts": {
+    "ops": "tsx cli.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx tests/rules.test.ts"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "yaml": "^2.3.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "tsx": "^4",
+    "typescript": "^5"
+  }
+}

--- a/tools/hive-ops/rules.ts
+++ b/tools/hive-ops/rules.ts
@@ -1,0 +1,600 @@
+// HiveOps — 28 programmatically-enforceable rules drawn from the canonical
+// docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md.
+//
+// Each rule:
+//   - is identified by a stable H-id (H01..H28). Never renumber; new rules
+//     get the next free ID, retired rules are tombstoned.
+//   - operates on the engine root (apps/<engine>/) — pure filesystem +
+//     parse, no network. Network checks (Vercel deploy URL 200, Cloudflare
+//     CNAME, Stripe products) live in HiveFinalize, not here.
+//
+// Pure: same engine root + same date = same result. The runner applies
+// override-file semantics on top of these results.
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { RuleDefinition, RuleContext } from "./types.js";
+
+const CANONICAL_LOCALES = ["en", "es", "fr", "ar", "hi", "zh", "pt"] as const;
+const HIVE_GOLD = "#D4AF37";
+
+// ---------------------------------------------------------------------------
+// Tiny helpers — no external deps so the package stays light.
+// ---------------------------------------------------------------------------
+
+function fileExists(path: string): boolean {
+  try { return statSync(path).isFile(); } catch { return false; }
+}
+
+function dirExists(path: string): boolean {
+  try { return statSync(path).isDirectory(); } catch { return false; }
+}
+
+function readIfExists(path: string): string | null {
+  try { return readFileSync(path, "utf8"); } catch { return null; }
+}
+
+function findRoot(ctx: RuleContext, relative: string): string {
+  return join(ctx.engineRoot, relative);
+}
+
+function searchAppFiles(ctx: RuleContext, paths: string[]): string | null {
+  for (const p of paths) {
+    const text = readIfExists(findRoot(ctx, p));
+    if (text !== null) return text;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// CORE BUILD (3)
+// ---------------------------------------------------------------------------
+
+const H01_packageJson: RuleDefinition = {
+  id: "H01",
+  title: "package.json present at engine root",
+  category: "CORE_BUILD",
+  severity: "MANDATORY",
+  unwaivable: true,
+  async check(ctx) {
+    const path = findRoot(ctx, "package.json");
+    return fileExists(path)
+      ? { status: "pass", message: `${path} exists` }
+      : { status: "fail", message: `missing ${path}` };
+  },
+};
+
+const H02_appRouter: RuleDefinition = {
+  id: "H02",
+  title: "Next.js app router root layout present",
+  category: "CORE_BUILD",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const candidates = ["app/layout.tsx", "app/layout.ts", "src/app/layout.tsx"];
+    for (const c of candidates) {
+      if (fileExists(findRoot(ctx, c))) {
+        return { status: "pass", message: `${c} exists` };
+      }
+    }
+    return { status: "fail", message: `none of ${candidates.join(", ")} exists` };
+  },
+};
+
+const H03_publicDir: RuleDefinition = {
+  id: "H03",
+  title: "public/ directory present",
+  category: "CORE_BUILD",
+  severity: "MANDATORY",
+  async check(ctx) {
+    return dirExists(findRoot(ctx, "public"))
+      ? { status: "pass", message: "public/ exists" }
+      : { status: "fail", message: "public/ directory missing" };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// INTERNATIONALIZATION (3)
+// ---------------------------------------------------------------------------
+
+const H04_localesDir: RuleDefinition = {
+  id: "H04",
+  title: "locales/ directory present",
+  category: "INTERNATIONALIZATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    return dirExists(findRoot(ctx, "locales"))
+      ? { status: "pass", message: "locales/ exists" }
+      : { status: "fail", message: "locales/ directory missing — strings must be externalized" };
+  },
+};
+
+const H05_canonicalLocaleSet: RuleDefinition = {
+  id: "H05",
+  title: "all 7 canonical free-tier locales present (en, es, fr, ar, hi, zh, pt)",
+  category: "INTERNATIONALIZATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const missing = CANONICAL_LOCALES.filter(
+      (loc) => !fileExists(findRoot(ctx, `locales/${loc}.json`)),
+    );
+    return missing.length === 0
+      ? { status: "pass", message: `all ${CANONICAL_LOCALES.length} locales present` }
+      : { status: "fail", message: `missing locales/${missing.join(".json, locales/")}.json` };
+  },
+};
+
+const H06_navigatorLanguageDetection: RuleDefinition = {
+  id: "H06",
+  title: "navigator.language detection wired in strings loader",
+  category: "INTERNATIONALIZATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const candidates = ["app/_lib/strings.ts", "src/lib/strings.ts", "lib/strings.ts", "app/strings.ts"];
+    for (const c of candidates) {
+      const text = readIfExists(findRoot(ctx, c));
+      if (text && /navigator\.language/.test(text)) {
+        return { status: "pass", message: `navigator.language reference found in ${c}` };
+      }
+    }
+    return { status: "fail", message: "no navigator.language reference in strings loader candidates" };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// SEO (4)
+// ---------------------------------------------------------------------------
+
+const H07_metadataExports: RuleDefinition = {
+  id: "H07",
+  title: "root layout exports metadata.title and metadata.description",
+  category: "SEO",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const text = searchAppFiles(ctx, ["app/layout.tsx", "src/app/layout.tsx"]);
+    if (!text) return { status: "skip", message: "no layout.tsx to check" };
+    const hasMetadata = /export\s+const\s+metadata/.test(text) || /export\s+function\s+generateMetadata/.test(text);
+    if (!hasMetadata) return { status: "fail", message: "neither `export const metadata` nor `generateMetadata` in layout" };
+    const hasTitle = /title\s*:/.test(text);
+    const hasDescription = /description\s*:/.test(text);
+    if (!hasTitle || !hasDescription) {
+      const missing = [!hasTitle && "title", !hasDescription && "description"].filter(Boolean).join(", ");
+      return { status: "fail", message: `metadata missing fields: ${missing}` };
+    }
+    return { status: "pass", message: "metadata.title + metadata.description present" };
+  },
+};
+
+const H08_ogImage: RuleDefinition = {
+  id: "H08",
+  title: "public/og.png present",
+  category: "SEO",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const path = findRoot(ctx, "public/og.png");
+    return fileExists(path)
+      ? { status: "pass", message: "public/og.png exists" }
+      : { status: "fail", message: "public/og.png missing — share previews fall back to Vercel default" };
+  },
+};
+
+const H09_robotsTxt: RuleDefinition = {
+  id: "H09",
+  title: "robots.txt present (public/ or app/robots.ts)",
+  category: "SEO",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const candidates = ["public/robots.txt", "app/robots.ts", "src/app/robots.ts"];
+    for (const c of candidates) {
+      if (fileExists(findRoot(ctx, c))) return { status: "pass", message: `${c} exists` };
+    }
+    return { status: "fail", message: `none of ${candidates.join(", ")} exists` };
+  },
+};
+
+const H10_sitemap: RuleDefinition = {
+  id: "H10",
+  title: "sitemap present (public/sitemap.xml or app/sitemap.ts)",
+  category: "SEO",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const candidates = ["public/sitemap.xml", "app/sitemap.ts", "src/app/sitemap.ts"];
+    for (const c of candidates) {
+      if (fileExists(findRoot(ctx, c))) return { status: "pass", message: `${c} exists` };
+    }
+    return { status: "fail", message: `none of ${candidates.join(", ")} exists` };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// FIRST-USE ONBOARDING (2)
+// ---------------------------------------------------------------------------
+
+const H11_installHint: RuleDefinition = {
+  id: "H11",
+  title: "PWA install hint banner present (HiveInstallHint or local equivalent)",
+  category: "FIRST_USE_ONBOARDING",
+  severity: "MANDATORY",
+  async check(ctx) {
+    // Either the engine imports @hive/onboarding's HiveInstallHint, or it
+    // ships a local equivalent named *InstallHint*.tsx under app/_lib or
+    // similar. Both are acceptable until Phase 3 lands.
+    const candidates = [
+      "app/page.tsx", "src/app/page.tsx",
+      "app/_lib/InstallHintBanner.tsx", "app/_lib/HiveInstallHint.tsx",
+    ];
+    for (const c of candidates) {
+      const text = readIfExists(findRoot(ctx, c));
+      if (text && /(InstallHint|@hive\/onboarding)/.test(text)) {
+        return { status: "pass", message: `install-hint reference found in ${c}` };
+      }
+    }
+    return { status: "fail", message: "no install-hint reference in primary surface files" };
+  },
+};
+
+const H12_firstVisitExplainer: RuleDefinition = {
+  id: "H12",
+  title: "first-visit explainer present (HiveFirstVisitExplainer or local equivalent)",
+  category: "FIRST_USE_ONBOARDING",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const candidates = [
+      "app/page.tsx", "src/app/page.tsx",
+      "app/_lib/InstallHintBanner.tsx", "app/_lib/HiveFirstVisitExplainer.tsx",
+    ];
+    for (const c of candidates) {
+      const text = readIfExists(findRoot(ctx, c));
+      if (text && /(FirstVisitExplainer|firstVisitExplainer)/.test(text)) {
+        return { status: "pass", message: `first-visit explainer reference found in ${c}` };
+      }
+    }
+    return { status: "fail", message: "no FirstVisitExplainer reference in primary surface files" };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// HIVE INTEGRATION (8)
+// ---------------------------------------------------------------------------
+
+const H13_hiveLogo: RuleDefinition = {
+  id: "H13",
+  title: "HIVE_HEADER_LOGO — public/hive-logo-full.png copied",
+  category: "HIVE_INTEGRATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const png = findRoot(ctx, "public/hive-logo-full.png");
+    const webp = findRoot(ctx, "public/hive-logo-full.webp");
+    if (fileExists(png) || fileExists(webp)) {
+      return { status: "pass", message: "hive-logo-full.{png|webp} present in public/" };
+    }
+    return { status: "fail", message: "public/hive-logo-full.png|webp missing" };
+  },
+};
+
+const H14_footerSignature: RuleDefinition = {
+  id: "H14",
+  title: 'HIVE_FOOTER_SIGNATURE — "Made with ♥ in the Hive" rendered',
+  category: "HIVE_INTEGRATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const candidates = [
+      "app/_lib/HiveFooter.tsx", "src/app/_lib/HiveFooter.tsx",
+      "app/page.tsx", "src/app/page.tsx",
+      "app/layout.tsx", "src/app/layout.tsx",
+    ];
+    for (const c of candidates) {
+      const text = readIfExists(findRoot(ctx, c));
+      if (text && /(Made with|madeWith).*Hive/s.test(text)) {
+        return { status: "pass", message: `footer signature reference found in ${c}` };
+      }
+    }
+    return { status: "fail", message: 'no "Made with ♥ in the Hive" reference in footer/page/layout' };
+  },
+};
+
+const H15_faviconComplete: RuleDefinition = {
+  id: "H15",
+  title: "FAVICON_COMPLETE — full canonical favicon set in public/",
+  category: "HIVE_INTEGRATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const required = ["favicon.ico", "icon-192.png", "icon-512.png", "apple-touch-icon.png"];
+    const optional = ["maskable-icon.png"];
+    const missing = required.filter((f) => !fileExists(findRoot(ctx, `public/${f}`)));
+    if (missing.length === 0) {
+      const optMissing = optional.filter((f) => !fileExists(findRoot(ctx, `public/${f}`)));
+      const note = optMissing.length === 0 ? "all required + maskable present" : `(maskable-icon.png missing — recommended)`;
+      return { status: "pass", message: `favicon set present ${note}` };
+    }
+    return { status: "fail", message: `missing public/${missing.join(", public/")}` };
+  },
+};
+
+const H16_themeColor: RuleDefinition = {
+  id: "H16",
+  title: `THEME_COLOR_CANONICAL — ${HIVE_GOLD} in metadata + manifest`,
+  category: "HIVE_INTEGRATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const layout = searchAppFiles(ctx, ["app/layout.tsx", "src/app/layout.tsx"]);
+    const manifest = readIfExists(findRoot(ctx, "public/manifest.json"));
+    const inLayout = layout ? new RegExp(`themeColor\\s*:\\s*['"\`]${HIVE_GOLD}['"\`]`, "i").test(layout) : false;
+    const inManifest = manifest ? new RegExp(`"theme_color"\\s*:\\s*"${HIVE_GOLD}"`, "i").test(manifest) : false;
+    if (inLayout && inManifest) return { status: "pass", message: `${HIVE_GOLD} present in layout themeColor and manifest theme_color` };
+    if (!inLayout && !inManifest) return { status: "fail", message: `${HIVE_GOLD} missing from both layout themeColor and manifest theme_color` };
+    return { status: "fail", message: `${HIVE_GOLD} only present in ${inLayout ? "layout" : "manifest"} — both required` };
+  },
+};
+
+const H17_appleWebApp: RuleDefinition = {
+  id: "H17",
+  title: "APPLE_WEB_APP_META — metadata.appleWebApp configured",
+  category: "HIVE_INTEGRATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const text = searchAppFiles(ctx, ["app/layout.tsx", "src/app/layout.tsx"]);
+    if (!text) return { status: "skip", message: "no layout.tsx to check" };
+    return /appleWebApp\s*:/.test(text)
+      ? { status: "pass", message: "appleWebApp key present in metadata" }
+      : { status: "fail", message: "metadata.appleWebApp missing — iOS standalone status bar will default" };
+  },
+};
+
+const H18_manifestComplete: RuleDefinition = {
+  id: "H18",
+  title: "MANIFEST_COMPLETE — public/manifest.json has canonical fields",
+  category: "HIVE_INTEGRATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const text = readIfExists(findRoot(ctx, "public/manifest.json"));
+    if (!text) return { status: "fail", message: "public/manifest.json missing" };
+    let m: Record<string, unknown>;
+    try { m = JSON.parse(text); } catch (err) {
+      return { status: "fail", message: `manifest.json invalid JSON: ${err instanceof Error ? err.message : String(err)}` };
+    }
+    const required = ["name", "short_name", "theme_color", "background_color", "display", "start_url", "icons"] as const;
+    const missing = required.filter((k) => !(k in m));
+    if (missing.length > 0) return { status: "fail", message: `manifest missing keys: ${missing.join(", ")}` };
+    if (m.display !== "standalone") return { status: "fail", message: `manifest.display=${JSON.stringify(m.display)} should be "standalone"` };
+    if (!Array.isArray(m.icons) || m.icons.length === 0) return { status: "fail", message: "manifest.icons must be a non-empty array" };
+    return { status: "pass", message: `manifest has all canonical fields (${(m.icons as unknown[]).length} icons)` };
+  },
+};
+
+const H19_engineGrammar: RuleDefinition = {
+  id: "H19",
+  title: "ENGINE_GRAMMAR.md present in repo root with frontmatter",
+  category: "HIVE_INTEGRATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const path = findRoot(ctx, "ENGINE_GRAMMAR.md");
+    if (!fileExists(path)) return { status: "fail", message: "ENGINE_GRAMMAR.md missing" };
+    const text = readIfExists(path);
+    if (!text) return { status: "fail", message: "ENGINE_GRAMMAR.md unreadable" };
+    return /^---\s*\n[\s\S]*?\n---/.test(text)
+      ? { status: "pass", message: "ENGINE_GRAMMAR.md present with YAML frontmatter" }
+      : { status: "fail", message: "ENGINE_GRAMMAR.md present but no YAML frontmatter detected" };
+  },
+};
+
+const H20_serviceWorker: RuleDefinition = {
+  id: "H20",
+  title: "service worker registrar present",
+  category: "HIVE_INTEGRATION",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const candidates = [
+      "public/sw.js", "public/service-worker.js",
+      "app/_lib/ServiceWorkerRegistrar.tsx", "src/app/_lib/ServiceWorkerRegistrar.tsx",
+    ];
+    for (const c of candidates) {
+      if (fileExists(findRoot(ctx, c))) return { status: "pass", message: `${c} present` };
+    }
+    return { status: "fail", message: `none of ${candidates.join(", ")} present` };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// VISIBILITY SURFACES (1)
+// ---------------------------------------------------------------------------
+
+const H21_planetEntry: RuleDefinition = {
+  id: "H21",
+  title: "engine entry present in hivebaby planet ENGINES array",
+  category: "VISIBILITY_SURFACES",
+  severity: "MANDATORY",
+  async check(ctx) {
+    // The hivebaby front door's ENGINES array lives in public/index.html
+    // (or public/lcars-data.js depending on layout). We look two levels up
+    // from the engine root for hivebaby/public.
+    const planetCandidates = [
+      join(ctx.engineRoot, "..", "..", "public", "index.html"),
+      join(ctx.engineRoot, "..", "..", "public", "engines.json"),
+      join(ctx.engineRoot, "..", "..", "engines.json"),
+    ];
+    for (const p of planetCandidates) {
+      const text = readIfExists(p);
+      if (text && new RegExp(ctx.engineSlug, "i").test(text)) {
+        return { status: "pass", message: `${ctx.engineSlug} referenced in ${p}` };
+      }
+    }
+    return { status: "fail", message: `no reference to ${ctx.engineSlug} in hivebaby planet/registry candidates` };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// DESIGN CONSISTENCY (2)
+// ---------------------------------------------------------------------------
+
+const H22_hiveGold: RuleDefinition = {
+  id: "H22",
+  title: `Hive gold ${HIVE_GOLD} referenced in component / styles`,
+  category: "DESIGN_CONSISTENCY",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const candidates = [
+      "app/layout.tsx", "src/app/layout.tsx",
+      "app/page.tsx", "src/app/page.tsx",
+      "app/globals.css", "src/app/globals.css",
+    ];
+    for (const c of candidates) {
+      const text = readIfExists(findRoot(ctx, c));
+      if (text && text.includes(HIVE_GOLD)) {
+        return { status: "pass", message: `${HIVE_GOLD} referenced in ${c}` };
+      }
+    }
+    return { status: "fail", message: `${HIVE_GOLD} not referenced in layout/page/globals` };
+  },
+};
+
+const H23_darkBackground: RuleDefinition = {
+  id: "H23",
+  title: "canonical dark ink #0a0a0a referenced",
+  category: "DESIGN_CONSISTENCY",
+  severity: "RECOMMENDED",
+  async check(ctx) {
+    const candidates = [
+      "app/layout.tsx", "src/app/layout.tsx",
+      "app/page.tsx", "src/app/page.tsx",
+      "app/globals.css", "src/app/globals.css",
+    ];
+    for (const c of candidates) {
+      const text = readIfExists(findRoot(ctx, c));
+      if (text && /#0a0a0a/i.test(text)) {
+        return { status: "pass", message: `#0a0a0a referenced in ${c}` };
+      }
+    }
+    return { status: "fail", message: "canonical ink #0a0a0a not referenced — engine may read as a stranger" };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// ADOPTION AMPLIFIERS (2)
+// ---------------------------------------------------------------------------
+
+const H24_pwaManifestRegistered: RuleDefinition = {
+  id: "H24",
+  title: 'manifest registered in layout (<link rel="manifest"...>)',
+  category: "ADOPTION_AMPLIFIERS",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const text = searchAppFiles(ctx, ["app/layout.tsx", "src/app/layout.tsx"]);
+    if (!text) return { status: "skip", message: "no layout.tsx to check" };
+    return /manifest\s*[:=]/.test(text) || /rel=['"]manifest['"]/.test(text)
+      ? { status: "pass", message: "manifest registered in layout (metadata.manifest or <link>)" }
+      : { status: "fail", message: "manifest not registered in layout — install prompts may not fire" };
+  },
+};
+
+const H25_mobileFirstViewport: RuleDefinition = {
+  id: "H25",
+  title: "viewport meta with width=device-width set in layout",
+  category: "ADOPTION_AMPLIFIERS",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const text = searchAppFiles(ctx, ["app/layout.tsx", "src/app/layout.tsx"]);
+    if (!text) return { status: "skip", message: "no layout.tsx to check" };
+    if (/viewport\s*:/.test(text)) {
+      // Next.js pulls viewport from `export const viewport`; just check the export exists.
+      return { status: "pass", message: "viewport export / metadata.viewport present in layout" };
+    }
+    return /width\s*=\s*device-width/i.test(text)
+      ? { status: "pass", message: "viewport meta found in layout" }
+      : { status: "fail", message: "no viewport export / device-width meta in layout — mobile rendering breaks" };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// OPERATIONAL (3)
+// ---------------------------------------------------------------------------
+
+const H26_envExample: RuleDefinition = {
+  id: "H26",
+  title: ".env.example or env_vars_required documented",
+  category: "OPERATIONAL",
+  severity: "RECOMMENDED",
+  async check(ctx) {
+    const envEx = findRoot(ctx, ".env.example");
+    if (fileExists(envEx)) return { status: "pass", message: ".env.example present" };
+    const grammar = readIfExists(findRoot(ctx, "ENGINE_GRAMMAR.md"));
+    if (grammar && /env_vars_required/.test(grammar)) {
+      return { status: "pass", message: "env_vars_required documented in ENGINE_GRAMMAR.md" };
+    }
+    return { status: "fail", message: "neither .env.example nor env_vars_required in grammar" };
+  },
+};
+
+const H27_readme: RuleDefinition = {
+  id: "H27",
+  title: "README.md present in engine root",
+  category: "OPERATIONAL",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const path = findRoot(ctx, "README.md");
+    if (!fileExists(path)) return { status: "fail", message: "README.md missing" };
+    const text = readIfExists(path);
+    if (!text || text.trim().length < 100) {
+      return { status: "fail", message: "README.md present but < 100 chars (placeholder?)" };
+    }
+    return { status: "pass", message: `README.md present (${text.length} chars)` };
+  },
+};
+
+const H28_tsconfig: RuleDefinition = {
+  id: "H28",
+  title: "tsconfig.json with strict mode",
+  category: "OPERATIONAL",
+  severity: "MANDATORY",
+  async check(ctx) {
+    const text = readIfExists(findRoot(ctx, "tsconfig.json"));
+    if (!text) return { status: "fail", message: "tsconfig.json missing" };
+    let cfg: { compilerOptions?: { strict?: boolean } };
+    try { cfg = JSON.parse(text) as typeof cfg; } catch (err) {
+      return { status: "fail", message: `tsconfig.json invalid JSON: ${err instanceof Error ? err.message : String(err)}` };
+    }
+    return cfg?.compilerOptions?.strict === true
+      ? { status: "pass", message: "tsconfig.json compilerOptions.strict=true" }
+      : { status: "fail", message: "tsconfig.json compilerOptions.strict is not true" };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export the canonical list. Order is the audit report order; never reshuffle
+// because the v0.2 baselines pin to this sequence.
+// ---------------------------------------------------------------------------
+
+export const RULES: ReadonlyArray<RuleDefinition> = [
+  H01_packageJson,
+  H02_appRouter,
+  H03_publicDir,
+  H04_localesDir,
+  H05_canonicalLocaleSet,
+  H06_navigatorLanguageDetection,
+  H07_metadataExports,
+  H08_ogImage,
+  H09_robotsTxt,
+  H10_sitemap,
+  H11_installHint,
+  H12_firstVisitExplainer,
+  H13_hiveLogo,
+  H14_footerSignature,
+  H15_faviconComplete,
+  H16_themeColor,
+  H17_appleWebApp,
+  H18_manifestComplete,
+  H19_engineGrammar,
+  H20_serviceWorker,
+  H21_planetEntry,
+  H22_hiveGold,
+  H23_darkBackground,
+  H24_pwaManifestRegistered,
+  H25_mobileFirstViewport,
+  H26_envExample,
+  H27_readme,
+  H28_tsconfig,
+];
+
+export const RULE_IDS: ReadonlySet<string> = new Set(RULES.map((r) => r.id));
+
+export const MANDATORY_COUNT = RULES.filter((r) => r.severity === "MANDATORY").length;
+export const RECOMMENDED_COUNT = RULES.filter((r) => r.severity === "RECOMMENDED").length;

--- a/tools/hive-ops/runner.ts
+++ b/tools/hive-ops/runner.ts
@@ -1,0 +1,98 @@
+// HiveOps runner — applies rule definitions + override schema to produce
+// an EngineReport. Pure: same inputs → same outputs.
+
+import { join, basename } from "node:path";
+import { existsSync } from "node:fs";
+import type { EngineReport, RuleResult, Verdict } from "./types.js";
+import { RULES, RULE_IDS } from "./rules.js";
+import { loadOverrides } from "./overrides.js";
+
+/** Resolve an engine slug to its on-disk root. Search order:
+ *  1. <repoRoot>/apps/<slug>
+ *  2. <repoRoot>/<slug>            (standalone repos cloned alongside)
+ *  Returns null if neither resolves. */
+export function resolveEngineRoot(repoRoot: string, slug: string): string | null {
+  const inApps = join(repoRoot, "apps", slug);
+  if (existsSync(inApps)) return inApps;
+  const standalone = join(repoRoot, slug);
+  if (existsSync(standalone)) return standalone;
+  return null;
+}
+
+export interface RunOptions {
+  /** Mockable date for deterministic warn-mode tests. Defaults to new Date(). */
+  now?: Date;
+}
+
+export async function runHiveOps(engineRoot: string, opts: RunOptions = {}): Promise<EngineReport> {
+  const now = opts.now ?? new Date();
+  const engineSlug = basename(engineRoot);
+  const overrides = loadOverrides(engineRoot, RULE_IDS);
+
+  const results: RuleResult[] = [];
+  const warnModeRules: Array<{ id: string; warnUntil: string }> = [];
+
+  for (const rule of RULES) {
+    const raw = await rule.check({ engineRoot, engineSlug, overrides, now });
+    const ov = overrides.byRule.get(rule.id);
+
+    let result: RuleResult = {
+      id: rule.id,
+      title: rule.title,
+      category: rule.category,
+      severity: rule.severity,
+      status: raw.status,
+      message: raw.message,
+      overrideApplied: false,
+    };
+
+    if (ov) {
+      // Unwaivable rules ignore the override (and the override is reported
+      // as a parse error so the violator notices).
+      if (rule.unwaivable) {
+        overrides.parseErrors.push(`overrides[${rule.id}]: rule ${rule.id} is unwaivable; override ignored`);
+      } else if (ov.mode === "waive") {
+        result = { ...result, status: "override", overrideApplied: true,
+          message: `WAIVED — ${ov.reason} (${ov.issue}, ${ov.reviewer}, ${ov.date}). Originally: ${raw.message}` };
+      } else if (ov.mode === "warn") {
+        const warnExpired = ov.warn_until !== undefined && Date.parse(ov.warn_until) < now.getTime();
+        if (warnExpired) {
+          // Expired warn → falls through to whatever the rule produced; if
+          // that's `fail`, surfaces in the report along with an explanatory
+          // note so the team knows the warn expired.
+          result = { ...result,
+            message: `${raw.message} — warn-mode override EXPIRED (${ov.warn_until}); ${ov.issue} must be resolved` };
+        } else if (raw.status === "fail") {
+          result = { ...result, status: "warn", overrideApplied: true,
+            warnUntil: ov.warn_until,
+            message: `WARN until ${ov.warn_until} — ${ov.reason} (${ov.issue}). Originally: ${raw.message}` };
+          warnModeRules.push({ id: rule.id, warnUntil: ov.warn_until ?? "" });
+        }
+        // pass / skip / override: warn-mode override has no effect
+      }
+    }
+
+    results.push(result);
+  }
+
+  return {
+    engineSlug,
+    engineRoot,
+    rules: results,
+    verdict: aggregateVerdict(results),
+    overrideParseErrors: overrides.parseErrors,
+    warnModeRules,
+  };
+}
+
+function aggregateVerdict(rules: RuleResult[]): Verdict {
+  let hasFail = false;
+  let hasWarn = false;
+  for (const r of rules) {
+    if (r.status === "fail") hasFail = true;
+    else if (r.status === "warn") hasWarn = true;
+  }
+  if (hasFail) return "fail";
+  if (hasWarn) return "warn";
+  return "pass";
+}

--- a/tools/hive-ops/tests/rules.test.ts
+++ b/tools/hive-ops/tests/rules.test.ts
@@ -1,0 +1,161 @@
+// HiveOps smoke tests — exercise the rule loader, override parser, and the
+// runner end-to-end against synthetic engine roots in /tmp.
+//
+// Run via: tsx tools/hive-ops/tests/rules.test.ts
+
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runHiveOps } from "../runner.js";
+import { RULES, RULE_IDS } from "../rules.js";
+import { loadOverrides } from "../overrides.js";
+
+let failures = 0;
+function check(label: string, cond: boolean, detail?: string): void {
+  if (!cond) {
+    failures += 1;
+    console.error(`FAIL: ${label}` + (detail ? ` — ${detail}` : ""));
+  } else {
+    console.log(`ok: ${label}`);
+  }
+}
+
+// Set up an empty engine root and assert the runner produces a fail
+// verdict with most rules failing.
+async function testEmptyEngineFails() {
+  const root = mkdtempSync(join(tmpdir(), "hive-ops-empty-"));
+  mkdirSync(join(root, "apps"), { recursive: true });
+  mkdirSync(join(root, "apps", "noop"));
+
+  const report = await runHiveOps(join(root, "apps", "noop"));
+  check("empty engine → verdict=fail", report.verdict === "fail");
+  check("empty engine → all rules ran (28)", report.rules.length === 28,
+    `got ${report.rules.length} rules`);
+  const failCount = report.rules.filter((r) => r.status === "fail").length;
+  check("empty engine → ≥20 rules fail", failCount >= 20, `failCount=${failCount}`);
+}
+
+// Override parser: malformed YAML reports an error.
+function testOverrideMalformedYaml() {
+  const root = mkdtempSync(join(tmpdir(), "hive-ops-bad-yaml-"));
+  writeFileSync(
+    join(root, "ENGINE_GRAMMAR.md"),
+    "## Hive-Ops Overrides\n\n```yaml\nthis is not: [valid: yaml\n```\n",
+  );
+  const o = loadOverrides(root, RULE_IDS);
+  check("malformed YAML reported as parse error", o.parseErrors.length > 0,
+    `errors=${JSON.stringify(o.parseErrors)}`);
+  check("malformed YAML produces no entries", o.byRule.size === 0);
+}
+
+// Override parser: complete valid override accepted.
+function testOverrideValid() {
+  const root = mkdtempSync(join(tmpdir(), "hive-ops-valid-"));
+  writeFileSync(
+    join(root, "ENGINE_GRAMMAR.md"),
+    [
+      "## Hive-Ops Overrides",
+      "",
+      "```yaml",
+      "overrides:",
+      "  - rule: H08",
+      "    mode: warn",
+      "    reason: \"OG image generator broken — workflow X tracks fix\"",
+      "    issue: https://github.com/saggarsonny-boop/hivebaby/issues/123",
+      "    reviewer: Sonny",
+      "    date: 2026-05-06",
+      "    warn_until: 2026-05-13",
+      "```",
+      "",
+    ].join("\n"),
+  );
+  const o = loadOverrides(root, RULE_IDS);
+  check("valid override → no parse errors", o.parseErrors.length === 0,
+    `errors=${JSON.stringify(o.parseErrors)}`);
+  check("valid override → entry registered", o.byRule.has("H08"));
+}
+
+// Override parser: warn_until > 30 days from date is rejected.
+function testOverrideWarnTooLong() {
+  const root = mkdtempSync(join(tmpdir(), "hive-ops-toolong-"));
+  writeFileSync(
+    join(root, "ENGINE_GRAMMAR.md"),
+    [
+      "## Hive-Ops Overrides",
+      "",
+      "```yaml",
+      "overrides:",
+      "  - rule: H08",
+      "    mode: warn",
+      "    reason: too long",
+      "    issue: https://github.com/x/y/issues/1",
+      "    reviewer: nope",
+      "    date: 2026-01-01",
+      "    warn_until: 2026-12-31", // ~365 days
+      "```",
+      "",
+    ].join("\n"),
+  );
+  const o = loadOverrides(root, RULE_IDS);
+  check("warn_until > 30d → parse error",
+    o.parseErrors.some((e) => e.includes("more than 30")),
+    `errors=${JSON.stringify(o.parseErrors)}`);
+}
+
+// Override parser: unknown rule ID rejected.
+function testOverrideUnknownRule() {
+  const root = mkdtempSync(join(tmpdir(), "hive-ops-unknown-"));
+  writeFileSync(
+    join(root, "ENGINE_GRAMMAR.md"),
+    [
+      "## Hive-Ops Overrides",
+      "",
+      "```yaml",
+      "overrides:",
+      "  - rule: H99",
+      "    mode: waive",
+      "    reason: who knows",
+      "    issue: https://github.com/x/y/issues/1",
+      "    reviewer: nope",
+      "    date: 2026-01-01",
+      "```",
+      "",
+    ].join("\n"),
+  );
+  const o = loadOverrides(root, RULE_IDS);
+  check("unknown rule ID → parse error",
+    o.parseErrors.some((e) => e.includes("not a known")),
+    `errors=${JSON.stringify(o.parseErrors)}`);
+}
+
+// MANDATORY/RECOMMENDED counts match user spec (28 total, 26 MANDATORY,
+// 2 RECOMMENDED). If you change the rules table, update this assertion to
+// match the new shape.
+function testRuleTableShape() {
+  check("RULES table has 28 entries", RULES.length === 28, `got ${RULES.length}`);
+  const m = RULES.filter((r) => r.severity === "MANDATORY").length;
+  const rec = RULES.filter((r) => r.severity === "RECOMMENDED").length;
+  check("28 = MANDATORY + RECOMMENDED", m + rec === 28, `MANDATORY=${m} RECOMMENDED=${rec}`);
+  check("rule IDs all match /^H\\d{2}$/", RULES.every((r) => /^H\d{2}$/.test(r.id)));
+  check("rule IDs unique", new Set(RULES.map((r) => r.id)).size === RULES.length);
+}
+
+async function main() {
+  testRuleTableShape();
+  testOverrideMalformedYaml();
+  testOverrideValid();
+  testOverrideWarnTooLong();
+  testOverrideUnknownRule();
+  await testEmptyEngineFails();
+
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+  }
+  console.log("\nall tests passed");
+}
+
+main().catch((err) => {
+  console.error("test runner crashed:", err);
+  process.exit(1);
+});

--- a/tools/hive-ops/tsconfig.json
+++ b/tools/hive-ops/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["es2022"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": false,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tools/hive-ops/types.ts
+++ b/tools/hive-ops/types.ts
@@ -1,0 +1,104 @@
+// HiveOps types — engine launch checklist enforcer.
+//
+// One Rule = one programmatically-enforceable item from the canonical
+// docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md. Rules are MANDATORY by
+// default; the override file at apps/<engine>/ENGINE_GRAMMAR.md can
+// downgrade specific rules to warn-mode (with a hard expiry) or waive
+// them entirely (requires GitHub issue + reviewer + date).
+//
+// Result statuses:
+//   pass — rule passed
+//   warn — rule failed but is in warn-mode (override schema), still allowed to ship
+//   fail — rule failed; blocks the engine from being marked LIVE
+//   skip — rule does not apply (e.g. service worker check on a static engine)
+//   override — rule is permanently waived via the override schema
+//
+// Verdict aggregation:
+//   any rule = fail   → engine verdict = fail
+//   no fails, ≥1 warn → engine verdict = warn
+//   else              → engine verdict = pass
+
+export type Severity = "MANDATORY" | "RECOMMENDED";
+export type RuleStatus = "pass" | "warn" | "fail" | "skip" | "override";
+
+export interface RuleContext {
+  /** Path to the engine root, e.g. /repo/apps/parkback. */
+  engineRoot: string;
+  /** Engine slug derived from the directory name, lowercase, hyphen-free. */
+  engineSlug: string;
+  /** Optional: parsed override file (ENGINE_GRAMMAR.md ## Hive-Ops Overrides block). */
+  overrides: ParsedOverrides;
+  /** Date the run is being executed (mockable for tests). */
+  now: Date;
+}
+
+export interface RuleResult {
+  /** Rule ID, e.g. "H01". Stable across time — never renumber. */
+  id: string;
+  /** One-line title from the canonical checklist. */
+  title: string;
+  /** Section the rule comes from (e.g. "HIVE_INTEGRATION"). */
+  category: string;
+  severity: Severity;
+  status: RuleStatus;
+  /** Human-readable evidence (what the check looked at + what it found). */
+  message: string;
+  /** True when status is `warn` or `override` because of an override entry. */
+  overrideApplied: boolean;
+  /** When status is `warn`, the date this warn-mode lapses to fail. */
+  warnUntil?: string;
+}
+
+export interface RuleDefinition {
+  id: string;
+  title: string;
+  category: string;
+  severity: Severity;
+  /** When true, the rule may not appear in the override schema (always enforced). */
+  unwaivable?: boolean;
+  /** Implementation. Returns an unscoped result; the runner applies overrides. */
+  check(ctx: RuleContext): Promise<Omit<RuleResult, "id" | "title" | "category" | "severity" | "overrideApplied" | "warnUntil">>;
+}
+
+// ---------------------------------------------------------------------------
+// Override schema (ENGINE_GRAMMAR.md ## Hive-Ops Overrides)
+// ---------------------------------------------------------------------------
+
+export interface OverrideEntry {
+  /** Rule ID, e.g. "H17". */
+  rule: string;
+  /** "warn" → degrade fail to warn until warn_until.
+   *  "waive" → permanent override; rule is reported as `override` regardless. */
+  mode: "warn" | "waive";
+  /** Why. Free-text. Required. */
+  reason: string;
+  /** GitHub issue tracking the eventual fix. Required for both modes. */
+  issue: string;
+  /** Reviewer's name. Required. */
+  reviewer: string;
+  /** YYYY-MM-DD when the override was added. */
+  date: string;
+  /** Required when mode=warn. Hard expiry; after this date the rule re-fires.
+   *  Default 7 days from date; max 30 days from date (validated by the loader). */
+  warn_until?: string;
+}
+
+export interface ParsedOverrides {
+  /** Map from rule ID → entry. */
+  byRule: Map<string, OverrideEntry>;
+  /** Errors encountered while parsing the override file (malformed YAML,
+   *  unknown rule IDs, missing fields, expired warns past 30-day max). */
+  parseErrors: string[];
+}
+
+export type Verdict = "pass" | "warn" | "fail";
+
+export interface EngineReport {
+  engineSlug: string;
+  engineRoot: string;
+  rules: RuleResult[];
+  verdict: Verdict;
+  overrideParseErrors: string[];
+  /** Rules currently in warn-mode (status==='warn') with their expiry dates. */
+  warnModeRules: Array<{ id: string; warnUntil: string }>;
+}


### PR DESCRIPTION
## Summary

Programmatic enforcer for `docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md`. Reads an engine root (`apps/<slug>/`), runs **28** filesystem-and-parse rules, applies any overrides declared in the engine's `ENGINE_GRAMMAR.md`, and emits a structured pass/warn/fail report.

This is **Phase 2** of the HiveOps v0.1 plan. Phase 3 (ParkBack consumes from `@hive/onboarding`) follows in a separate PR.

## Rules (28 total · 26 MANDATORY · 2 RECOMMENDED)

Drawn from the canonical checklist, organized as `H01..H28` across nine categories:

- **CORE_BUILD** (3): package.json, app router root layout, public/
- **INTERNATIONALIZATION** (3): locales/ dir, all 7 canonical locales, navigator.language detection
- **SEO** (4): metadata.title+description, og.png, robots, sitemap
- **FIRST_USE_ONBOARDING** (2): InstallHint, FirstVisitExplainer (`@hive/onboarding` or local equivalent accepted)
- **HIVE_INTEGRATION** (8): logo, footer signature, favicon set, theme color, appleWebApp, manifest, ENGINE_GRAMMAR, service worker
- **VISIBILITY_SURFACES** (1): planet ENGINES array entry
- **DESIGN_CONSISTENCY** (2): Hive gold #D4AF37, ink #0a0a0a (recommended)
- **ADOPTION_AMPLIFIERS** (2): manifest registered in layout, viewport meta
- **OPERATIONAL** (3): env documentation (recommended), README ≥100 chars, tsconfig strict

## Override schema

Engines can downgrade or waive a rule via a YAML block in `ENGINE_GRAMMAR.md`:

```yaml
overrides:
  - rule: H08
    mode: warn          # or "waive"
    reason: "OG image generator broken; tracked in workflow X."
    issue: https://github.com/saggarsonny-boop/hivebaby/issues/123
    reviewer: Sonny
    date: 2026-05-06
    warn_until: 2026-05-13   # required for warn; default +7d, max +30d
```

- `mode: warn` degrades fail to warn until `warn_until` (then automatically lapses back to fail with explanatory note)
- `mode: waive` is permanent override; reported as `override` in the report
- Every entry requires `rule, mode, reason, issue (GH issue URL), reviewer, date`
- Unwaivable rules (currently H01) reject any override entry

## CI integration

`.github/workflows/hive-ops.yml` runs on PRs touching `apps/`, `tools/hive-ops/`, or `packages/hive-onboarding/`. Failing verdicts block merge. Manual `workflow_dispatch` supported for one-shot audits.

## Tests

`tools/hive-ops/tests/rules.test.ts` — zero-dependency Node tests covering the rule table shape, override parser (malformed YAML, valid entries, warn_until > 30d rejection, unknown rule ID rejection), and end-to-end runner against a synthetic empty engine root.

```
$ npx tsx tests/rules.test.ts
ok: RULES table has 28 entries
ok: 28 = MANDATORY + RECOMMENDED
ok: rule IDs all match /^H\d{2}$/
ok: rule IDs unique
ok: malformed YAML reported as parse error
ok: malformed YAML produces no entries
ok: valid override → no parse errors
ok: valid override → entry registered
ok: warn_until > 30d → parse error
ok: unknown rule ID → parse error
ok: empty engine → verdict=fail
ok: empty engine → all rules ran (28)
ok: empty engine → ≥20 rules fail

all tests passed
```

## Real-engine smoke test

Audit run against `apps/parkback/`:

```
tally: pass=26 warn=0 fail=2 skip=0 override=0
VERDICT: FAIL
```

Two real findings — both legitimate gaps, neither caused by HiveOps mis-detection:

| Rule | Severity | Finding |
|---|---|---|
| H19 | MANDATORY | `ENGINE_GRAMMAR.md present but no YAML frontmatter detected` |
| H26 | RECOMMENDED | `neither .env.example nor env_vars_required in grammar` |

Both will surface in the Phase 3 final-audit report.

## Documentation

- `tools/hive-ops/README.md` — full rule list + override schema docs + warn-mode philosophy
- `docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md` — gains a "Programmatic enforcement — HiveOps" section pointing at the CLI

## Test plan

- [x] `npx tsc --noEmit` clean from `tools/hive-ops/`
- [x] `npx tsx tests/rules.test.ts` — 13/13 pass
- [x] Real engine audit on ParkBack produces correct findings (no false positives observed)
- [ ] CI workflow runs on this PR's diff (covers `tools/hive-ops/**` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)