### PR TITLE
ops(hive-aestheticbestie): warn-mode overrides for 22 outstanding HiveOps fails (issue #93)

### DIFF
--- a/hive-aestheticbestie/ENGINE_GRAMMAR.md
+++ b/hive-aestheticbestie/ENGINE_GRAMMAR.md
@@ -84,3 +84,207 @@ being seen by a best friend.
 ## Deployment Notes
 - Auto-deploy on push to main
 - Cloudflare CNAME → cname.vercel-dns.com
+
+## Hive-Ops Overrides
+
+```yaml
+overrides:
+  - rule: H03
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: public/ directory present
+    # message:  public/ directory missing
+  - rule: H04
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: locales/ directory present
+    # message:  locales/ directory missing — strings must be externalized
+  - rule: H05
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: all 7 canonical free-tier locales present (en, es, fr, ar, hi, zh, pt)
+    # message:  missing locales/en.json, locales/es.json, locales/fr.json, locales/ar.json, locales/hi.json, locales/zh.json, locales/pt.json
+  - rule: H06
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: navigator.language detection wired in strings loader
+    # message:  no navigator.language reference in strings loader candidates
+  - rule: H08
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: public/og.png present
+    # message:  public/og.png missing — share previews fall back to Vercel default
+  - rule: H09
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: robots.txt present (public/ or app/robots.ts)
+    # message:  none of public/robots.txt, app/robots.ts, src/app/robots.ts exists
+  - rule: H10
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: sitemap present (public/sitemap.xml or app/sitemap.ts)
+    # message:  none of public/sitemap.xml, app/sitemap.ts, src/app/sitemap.ts exists
+  - rule: H11
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: PWA install hint banner present (HiveInstallHint or local equivalent)
+    # message:  no install-hint reference in primary surface files
+  - rule: H12
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: first-visit explainer present (HiveFirstVisitExplainer or local equivalent)
+    # message:  no FirstVisitExplainer reference in primary surface files
+  - rule: H13
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: HIVE_HEADER_LOGO — public/hive-logo-full.png copied
+    # message:  public/hive-logo-full.png|webp missing
+  - rule: H14
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: HIVE_FOOTER_SIGNATURE — "Made with ♥ in the Hive" rendered
+    # message:  no "Made with ♥ in the Hive" reference in footer/page/layout
+  - rule: H15
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: FAVICON_COMPLETE — full canonical favicon set in public/
+    # message:  missing public/favicon.ico, public/icon-192.png, public/icon-512.png, public/apple-touch-icon.png
+  - rule: H16
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: THEME_COLOR_CANONICAL — #D4AF37 in metadata + manifest
+    # message:  #D4AF37 missing from both layout themeColor and manifest theme_color
+  - rule: H17
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: APPLE_WEB_APP_META — metadata.appleWebApp configured
+    # message:  metadata.appleWebApp missing — iOS standalone status bar will default
+  - rule: H18
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: MANIFEST_COMPLETE — public/manifest.json has canonical fields
+    # message:  public/manifest.json missing
+  - rule: H20
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: service worker registrar present
+    # message:  none of public/sw.js, public/service-worker.js, app/_lib/ServiceWorkerRegistrar.tsx, src/app/_lib/ServiceWorkerRegistrar.tsx present
+  - rule: H21
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: engine entry present in hivebaby planet ENGINES array
+    # message:  no reference to hive-aestheticbestie in hivebaby planet/registry candidates
+  - rule: H22
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: Hive gold #D4AF37 referenced in component / styles
+    # message:  #D4AF37 not referenced in layout/page/globals
+  - rule: H23
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: canonical dark ink #0a0a0a referenced
+    # message:  canonical ink #0a0a0a not referenced — engine may read as a stranger
+  - rule: H24
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: manifest registered in layout (<link rel="manifest"...>)
+    # message:  manifest not registered in layout — install prompts may not fire
+  - rule: H25
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: viewport meta with width=device-width set in layout
+    # message:  no viewport export / device-width meta in layout — mobile rendering breaks
+  - rule: V19
+    mode: warn
+    reason: "Hive-aestheticbestie pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in hivebaby#93; warn-mode for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates."
+    issue: "https://github.com/saggarsonny-boop/hivebaby/issues/93"
+    reviewer: Sonny
+    date: 2026-05-06
+    warn_until: 2026-06-05
+    # original: live → checklist all true
+    # message:  not true: test_slot, seo_layout, health_check, health_workflow_listed
+```


### PR DESCRIPTION
## Summary

Ships warn-mode overrides for 22 HiveOps fails on `hive-aestheticbestie`. Engine pre-dates the canonical HiveOps v0.1+ Hive-integration standards. Full remediation tracked in [#93](https://github.com/saggarsonny-boop/hivebaby/issues/93); this PR puts the verdict at WARN (not FAIL) for 30 days while the canonical-finalization PR is scoped against the parkback / ud-converter templates.

## Verdict change

| | Pass | Warn | Fail | Skip | Override | Verdict |
|---|---|---|---|---|---|---|
| Before | 30 | 0 | **22** | 5 | 0 | ❌ FAIL |
| After | 30 | **22** | 0 | 5 | 0 | ⚠️ WARN |

## Generation

```sh
tsx tools/hive-ops/cli.ts hive-aestheticbestie \
  --write-overrides --apply --warn-days 30 --reviewer Sonny
```

Then placeholders replaced programmatically with the structured reason + tracking issue URL (one substitution across all 22 entries — they share the same root cause).

## Tracking issue

[hivebaby#93 — HiveOps remediation: hive-aestheticbestie](https://github.com/saggarsonny-boop/hivebaby/issues/93) lists every fail with rule ID + original message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)