### PR TITLE
fix(hive-ops): guard daily-report issue step with shell file-check

### DIFF
--- a/.github/workflows/hive-ops-daily-sweep.yml
+++ b/.github/workflows/hive-ops-daily-sweep.yml
@@ -126,12 +126,19 @@ jobs:
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
       - name: Open or update daily report issue
-        if: github.event.inputs.dry_run != 'true' && hashFiles('/tmp/hive-ops-sweep-issue.md') != ''
+        # hashFiles() only resolves paths inside the workspace, so we
+        # gate on dry-run at the YAML layer and check the actual /tmp
+        # body file inside the shell — see PR #107 for context.
+        if: github.event.inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TODAY: ${{ steps.sweep.outputs.today }}
         run: |
           set -euo pipefail
+          if [ ! -f /tmp/hive-ops-sweep-issue.md ]; then
+            echo "Sweep wrote no issue body (likely a tooling-error short-circuit). Skipping."
+            exit 0
+          fi
           TITLE="HiveOps Daily Sweep Report ${TODAY}"
           # gh issue list will return a JSON array; reuse today's issue
           # if it already exists (e.g. someone manually re-ran the


### PR DESCRIPTION
## Summary

Follow-up to #100 / #105. The daily-sweep workflow's "Open or update daily report issue" step used `hashFiles('/tmp/hive-ops-sweep-issue.md')` in its `if:` condition, but `hashFiles()` only resolves paths inside the workspace — absolute `/tmp` paths always return empty, so the step never fired.

Verified in smoke run [25462020294](https://github.com/saggarsonny-boop/hivebaby/actions/runs/25462020294): the sweep itself does write `/tmp/hive-ops-sweep-issue.md` correctly; only the workflow-layer guard was wrong.

Replaces the `hashFiles()` check with a shell-side `[ -f ... ]` test inside the step. The dry-run gate stays at the YAML layer.

## Test plan

- [x] YAML parses locally with both `schedule` + `workflow_dispatch` triggers
- [ ] CI green
- [ ] Post-merge: `gh workflow run hive-ops-daily-sweep.yml` triggers a smoke run that creates today's "HiveOps Daily Sweep Report YYYY-MM-DD" issue (currently missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)