### PR TITLE
fix(hive-activity-partner): re-ship Phase 2 backend (PR #111 was empty)

### DIFF
--- a/apps/hive-activity-partner/app/api/activities/list/route.ts
+++ b/apps/hive-activity-partner/app/api/activities/list/route.ts
@@ -1,0 +1,52 @@
+// GET /api/activities/list — return the active taxonomy. Optional ?category=
+// filter (sport, fitness, creative, intellectual, outdoor, social). Cached
+// for one hour at the edge; the taxonomy changes only on operator approval.
+
+import { NextResponse } from "next/server";
+import { sql } from "@/lib/db";
+import { isCategory, type Category } from "@/lib/validation/activity";
+
+export const dynamic = "force-dynamic";
+
+type Row = {
+  id: string;
+  slug: string;
+  display_name: string;
+  category: Category;
+};
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const categoryParam = url.searchParams.get("category");
+  const category = categoryParam && isCategory(categoryParam) ? categoryParam : null;
+
+  const rows = (await (category
+    ? sql`
+        SELECT id, slug, display_name, category
+        FROM hap_activity_taxonomy
+        WHERE is_active = true AND is_pending_moderation = false AND category = ${category}
+        ORDER BY display_name ASC
+      `
+    : sql`
+        SELECT id, slug, display_name, category
+        FROM hap_activity_taxonomy
+        WHERE is_active = true AND is_pending_moderation = false
+        ORDER BY category ASC, display_name ASC
+      `)) as Row[];
+
+  return NextResponse.json(
+    {
+      activities: rows.map((r) => ({
+        id: r.id,
+        slug: r.slug,
+        displayName: r.display_name,
+        category: r.category,
+      })),
+    },
+    {
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    },
+  );
+}

--- a/apps/hive-activity-partner/app/api/activities/moderate/[id]/route.ts
+++ b/apps/hive-activity-partner/app/api/activities/moderate/[id]/route.ts
@@ -1,0 +1,91 @@
+// POST /api/activities/moderate/[id] — operator-only. Approve/reject a
+// pending activity request. Approved → is_active=true, is_pending_moderation=false.
+// Rejected → is_active=false, is_pending_moderation=false (kept for audit;
+// operator can re-list later if appealed). Every decision writes both
+// hap_moderation_log and hap_operator_audit.
+
+import { NextResponse } from "next/server";
+import { sql } from "@/lib/db";
+import { requireOperator, newRequestId } from "@/lib/operator-auth";
+import { auditOperatorAction } from "@/lib/db-operator";
+import { isUuid } from "@/lib/validation/activity";
+
+export const dynamic = "force-dynamic";
+
+const DECISIONS = ["approved", "rejected"] as const;
+type Decision = (typeof DECISIONS)[number];
+
+type Body = {
+  decision: Decision;
+  reason?: string | null;
+};
+
+function bad(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  let op;
+  try {
+    op = await requireOperator(req);
+  } catch {
+    return bad("OPERATOR_REQUIRED", 401);
+  }
+
+  const { id } = await ctx.params;
+  if (!isUuid(id)) return bad("invalid id", 400);
+
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return bad("invalid JSON", 400);
+  }
+
+  if (!DECISIONS.includes(body.decision)) {
+    return bad(`decision must be one of: ${DECISIONS.join(", ")}`, 400);
+  }
+  const reason = body.reason ? String(body.reason).trim().slice(0, 500) : null;
+  if (body.decision === "rejected" && (!reason || reason.length === 0)) {
+    return bad("rejection requires a reason", 400);
+  }
+
+  const target = (await sql`
+    SELECT id, is_pending_moderation FROM hap_activity_taxonomy WHERE id = ${id} LIMIT 1
+  `) as Array<{ id: string; is_pending_moderation: boolean }>;
+  if (target.length === 0) return bad("not found", 404);
+  if (!target[0].is_pending_moderation) {
+    return bad("already moderated", 409);
+  }
+
+  const requestId = newRequestId();
+  if (body.decision === "approved") {
+    await sql`
+      UPDATE hap_activity_taxonomy
+      SET is_active = true, is_pending_moderation = false
+      WHERE id = ${id}
+    `;
+  } else {
+    await sql`
+      UPDATE hap_activity_taxonomy
+      SET is_active = false, is_pending_moderation = false
+      WHERE id = ${id}
+    `;
+  }
+
+  await sql`
+    INSERT INTO hap_moderation_log (taxonomy_id, decision, reason, moderator_identity, request_id)
+    VALUES (${id}, ${body.decision}, ${reason}, ${op.identity}, ${requestId})
+  `;
+
+  await auditOperatorAction({
+    identity: op,
+    action: `activities.moderate.${body.decision}`,
+    targetId: id,
+    targetType: "hap_activity_taxonomy",
+    requestId,
+    metadata: reason ? { reason } : null,
+  });
+
+  return NextResponse.json({ id, decision: body.decision });
+}

--- a/apps/hive-activity-partner/app/api/activities/moderate/route.ts
+++ b/apps/hive-activity-partner/app/api/activities/moderate/route.ts
@@ -1,0 +1,59 @@
+// GET /api/activities/moderate — operator-only. Returns activities awaiting
+// review (is_pending_moderation=true), oldest first, with the requester's
+// city + age band so moderators see the ask in context. Does not return
+// exact_location_lat/lng (defense in depth).
+
+import { NextResponse } from "next/server";
+import { sql } from "@/lib/db";
+import { requireOperator } from "@/lib/operator-auth";
+
+export const dynamic = "force-dynamic";
+
+type Row = {
+  id: string;
+  slug: string;
+  display_name: string;
+  category: string;
+  requested_by_user_id: string | null;
+  created_at: string;
+  requester_city: string | null;
+  requester_age_band: string | null;
+  justification: string | null;
+};
+
+export async function GET(req: Request) {
+  try {
+    await requireOperator(req);
+  } catch {
+    return NextResponse.json({ error: "OPERATOR_REQUIRED" }, { status: 401 });
+  }
+
+  const rows = (await sql`
+    SELECT t.id, t.slug, t.display_name, t.category, t.requested_by_user_id,
+           t.created_at, u.city AS requester_city, u.age_band AS requester_age_band,
+           (
+             SELECT reason FROM hap_moderation_log m
+             WHERE m.taxonomy_id = t.id AND m.reason LIKE 'REQUEST:%'
+             ORDER BY m.created_at ASC LIMIT 1
+           ) AS justification
+    FROM hap_activity_taxonomy t
+    LEFT JOIN hap_users u ON u.id = t.requested_by_user_id
+    WHERE t.is_pending_moderation = true
+    ORDER BY t.created_at ASC
+    LIMIT 100
+  `) as Row[];
+
+  return NextResponse.json({
+    pending: rows.map((r) => ({
+      id: r.id,
+      slug: r.slug,
+      displayName: r.display_name,
+      category: r.category,
+      requestedByUserId: r.requested_by_user_id,
+      createdAt: r.created_at,
+      requesterCity: r.requester_city,
+      requesterAgeBand: r.requester_age_band,
+      justification: r.justification ? r.justification.replace(/^REQUEST: /, "") : null,
+    })),
+  });
+}

--- a/apps/hive-activity-partner/app/api/activities/request/route.ts
+++ b/apps/hive-activity-partner/app/api/activities/request/route.ts
@@ -1,0 +1,93 @@
+// POST /api/activities/request — user-requested new activity. Lands in
+// hap_activity_taxonomy with is_active=false, is_pending_moderation=true,
+// requested_by_user_id=<user>. Operator approves/rejects via /api/activities/moderate.
+//
+// Rate-limited to 1 request per user per 7 days to deter spam — checked
+// against requested_by_user_id + created_at.
+
+import { NextResponse } from "next/server";
+import { sql } from "@/lib/db";
+import { requireHapUser } from "@/lib/auth";
+import { validateActivityRequest } from "@/lib/validation/activity";
+
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT_DAYS = 7;
+
+function badRequest(errors: { field: string; message: string }[]) {
+  return NextResponse.json({ error: "VALIDATION_FAILED", errors }, { status: 400 });
+}
+
+function fromError(e: unknown): NextResponse | null {
+  const status = (e as { status?: number })?.status;
+  if (status === 401) return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  if (status === 403) return NextResponse.json({ error: "SUSPENDED" }, { status: 403 });
+  if (status === 404) return NextResponse.json({ error: "PROFILE_REQUIRED" }, { status: 404 });
+  return null;
+}
+
+export async function POST(req: Request) {
+  let me;
+  try {
+    me = await requireHapUser();
+  } catch (e) {
+    const r = fromError(e);
+    if (r) return r;
+    throw e;
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return badRequest([{ field: "body", message: "invalid JSON" }]);
+  }
+
+  const result = validateActivityRequest(body);
+  if (!result.ok) return badRequest(result.errors);
+  const { slug, displayName, category, justification } = result.value;
+
+  // Rate-limit: 1 request per RATE_LIMIT_DAYS per user.
+  const cutoffIso = new Date(
+    Date.now() - RATE_LIMIT_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const recent = (await sql`
+    SELECT id FROM hap_activity_taxonomy
+    WHERE requested_by_user_id = ${me.id}
+      AND created_at > ${cutoffIso}::timestamptz
+    LIMIT 1
+  `) as Array<{ id: string }>;
+  if (recent.length > 0) {
+    return NextResponse.json(
+      { error: "RATE_LIMITED", retryAfterDays: RATE_LIMIT_DAYS },
+      { status: 429 },
+    );
+  }
+
+  // Slug clash with an existing active row → reject with 409 so the user
+  // knows the activity already exists.
+  const clash = (await sql`
+    SELECT id, is_active FROM hap_activity_taxonomy WHERE slug = ${slug} LIMIT 1
+  `) as Array<{ id: string; is_active: boolean }>;
+  if (clash.length > 0) {
+    return NextResponse.json(
+      { error: "SLUG_TAKEN", existingId: clash[0].id, existingActive: clash[0].is_active },
+      { status: 409 },
+    );
+  }
+
+  const inserted = (await sql`
+    INSERT INTO hap_activity_taxonomy (slug, display_name, category, is_active, is_pending_moderation, requested_by_user_id)
+    VALUES (${slug}, ${displayName}, ${category}, false, true, ${me.id})
+    RETURNING id
+  `) as Array<{ id: string }>;
+
+  // Justification is captured into hap_moderation_log up front so moderators
+  // see the original ask without needing to query hap_users for the requester.
+  await sql`
+    INSERT INTO hap_moderation_log (taxonomy_id, decision, reason, moderator_identity)
+    VALUES (${inserted[0].id}, 'archived', ${"REQUEST: " + justification}, ${"user:" + me.id})
+  `;
+
+  return NextResponse.json({ id: inserted[0].id, status: "pending_review" }, { status: 201 });
+}

--- a/apps/hive-activity-partner/app/api/health/route.ts
+++ b/apps/hive-activity-partner/app/api/health/route.ts
@@ -1,11 +1,30 @@
-// Engine health check. Returns 200 with engine identity + a quick DB
-// liveness probe. Used by the HiveOps audit (V19 launch_checklist health_check)
-// and any external monitor.
+// Engine health check. Returns 200 with engine identity, a quick DB
+// liveness probe, and Phase 2 activity-stats summary. Used by the HiveOps
+// audit (V19 launch_checklist health_check) and any external monitor.
+//
+// activity-stats fields:
+//   total_taxonomy_count          — active taxonomy rows (excl. pending)
+//   pending_moderation_count      — rows awaiting operator decision
+//   total_user_activities         — active rows across all users
+//   last_24h_user_activities      — added in the last 24h
+//   last_24h_taxonomy_requests    — user-requested rows in the last 24h
 
 import { NextResponse } from "next/server";
 import { sql } from "@/lib/db";
 
 export const dynamic = "force-dynamic";
+
+type CountRow = { c: number };
+
+async function safeCount(query: Promise<unknown>): Promise<number | null> {
+  try {
+    const rows = (await query) as CountRow[];
+    const v = rows[0]?.c;
+    return typeof v === "number" ? v : Number(v ?? 0);
+  } catch {
+    return null;
+  }
+}
 
 export async function GET() {
   let dbOk = false;
@@ -16,12 +35,55 @@ export async function GET() {
     dbOk = false;
   }
 
+  let activityStats: Record<string, number | null> | null = null;
+  if (dbOk) {
+    const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+    const [
+      totalTaxonomy,
+      pendingModeration,
+      totalUserActivities,
+      last24hUserActivities,
+      last24hTaxonomyRequests,
+    ] = await Promise.all([
+      safeCount(
+        sql`SELECT COUNT(*)::int AS c FROM hap_activity_taxonomy
+            WHERE is_active = true AND is_pending_moderation = false`,
+      ),
+      safeCount(
+        sql`SELECT COUNT(*)::int AS c FROM hap_activity_taxonomy
+            WHERE is_pending_moderation = true`,
+      ),
+      safeCount(
+        sql`SELECT COUNT(*)::int AS c FROM hap_user_activities WHERE is_active = true`,
+      ),
+      safeCount(
+        sql`SELECT COUNT(*)::int AS c FROM hap_user_activities
+            WHERE is_active = true AND created_at > ${since24h}::timestamptz`,
+      ),
+      safeCount(
+        sql`SELECT COUNT(*)::int AS c FROM hap_activity_taxonomy
+            WHERE requested_by_user_id IS NOT NULL
+              AND created_at > ${since24h}::timestamptz`,
+      ),
+    ]);
+
+    activityStats = {
+      total_taxonomy_count: totalTaxonomy,
+      pending_moderation_count: pendingModeration,
+      total_user_activities: totalUserActivities,
+      last_24h_user_activities: last24hUserActivities,
+      last_24h_taxonomy_requests: last24hTaxonomyRequests,
+    };
+  }
+
   return NextResponse.json(
     {
       engine: "hive-activity-partner",
       version: "0.1.0",
       ok: dbOk,
       timestamp: new Date().toISOString(),
+      activity_stats: activityStats,
     },
     { status: dbOk ? 200 : 503 },
   );

--- a/apps/hive-activity-partner/app/api/operator/login/route.ts
+++ b/apps/hive-activity-partner/app/api/operator/login/route.ts
@@ -1,0 +1,78 @@
+// POST /api/operator/login — exchange a single-use OPERATOR_SETUP_CODE for
+// the signed hap_operator cookie. The code is hashed (SHA-256) and the hash
+// stored in hap_operator_setup_code_state on success, so the same code
+// can't be replayed even if leaked. The operator rotates the env var after
+// each issuance per Constitution §V.
+
+import { NextResponse } from "next/server";
+import { sql } from "@/lib/db";
+import {
+  OPERATOR_COOKIE_NAME,
+  OPERATOR_COOKIE_TTL_SECONDS,
+  getConfiguredSetupCode,
+  hashSetupCode,
+  issueOperatorCookieValue,
+  newRequestId,
+  setupCodeMatches,
+} from "@/lib/operator-auth";
+
+export const dynamic = "force-dynamic";
+
+type Body = { code?: unknown; identity?: unknown };
+
+function bad(error: string, status: number) {
+  return NextResponse.json({ error }, { status });
+}
+
+export async function POST(req: Request) {
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return bad("invalid JSON", 400);
+  }
+
+  const code = typeof body.code === "string" ? body.code.trim() : "";
+  const identityRaw =
+    typeof body.identity === "string" ? body.identity.trim().slice(0, 80) : "";
+  const identity = identityRaw || "anon";
+
+  if (!code) return bad("code is required", 400);
+  if (!/^[0-9]{6}$/.test(code)) return bad("code must be 6 digits", 400);
+
+  const configured = getConfiguredSetupCode();
+  if (!configured) return bad("operator login is not configured", 503);
+  if (!setupCodeMatches(code, configured)) {
+    return bad("UNAUTHORIZED", 401);
+  }
+
+  const requestId = newRequestId();
+  const codeHash = hashSetupCode(code);
+
+  // Single-use: try to insert the consumed-code row; if a row already exists
+  // for this hash, the code has been used — reject so it can't be replayed.
+  const inserted = (await sql`
+    INSERT INTO hap_operator_setup_code_state (code_hash, consumed_by_identity, request_id)
+    VALUES (${codeHash}, ${identity}, ${requestId})
+    ON CONFLICT (code_hash) DO NOTHING
+    RETURNING code_hash
+  `) as Array<{ code_hash: string }>;
+  if (inserted.length === 0) {
+    return bad("CODE_ALREADY_USED", 409);
+  }
+
+  const cookieValue = issueOperatorCookieValue(`setup:${identity}`);
+  if (!cookieValue) {
+    return bad("operator cookie signing key not configured", 503);
+  }
+
+  const res = NextResponse.json({ ok: true, ttlSeconds: OPERATOR_COOKIE_TTL_SECONDS });
+  res.cookies.set(OPERATOR_COOKIE_NAME, cookieValue, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "strict",
+    path: "/",
+    maxAge: OPERATOR_COOKIE_TTL_SECONDS,
+  });
+  return res;
+}

--- a/apps/hive-activity-partner/app/api/users/me/activities/[id]/route.ts
+++ b/apps/hive-activity-partner/app/api/users/me/activities/[id]/route.ts
@@ -1,0 +1,105 @@
+// PATCH /api/users/me/activities/[id] — partial update of one of the user's
+// activity rows. Only the row owner can update; operator role does NOT bypass
+// here (operator audit is for taxonomy-level moderation, not impersonation).
+//
+// DELETE /api/users/me/activities/[id] — soft delete via is_active=false.
+// The row stays for audit; re-adding the same activity reactivates it via
+// POST /api/users/me/activities.
+
+import { NextResponse } from "next/server";
+import { sql } from "@/lib/db";
+import { requireHapUser } from "@/lib/auth";
+import { isUuid, validateUserActivityPatch } from "@/lib/validation/activity";
+
+export const dynamic = "force-dynamic";
+
+function fromError(e: unknown): NextResponse | null {
+  const status = (e as { status?: number })?.status;
+  if (status === 401) return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  if (status === 403) return NextResponse.json({ error: "SUSPENDED" }, { status: 403 });
+  if (status === 404) return NextResponse.json({ error: "PROFILE_REQUIRED" }, { status: 404 });
+  return null;
+}
+
+async function loadOwned(rowId: string, userId: string) {
+  const rows = (await sql`
+    SELECT id FROM hap_user_activities
+    WHERE id = ${rowId} AND user_id = ${userId}
+    LIMIT 1
+  `) as Array<{ id: string }>;
+  return rows[0] ?? null;
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  let me;
+  try {
+    me = await requireHapUser();
+  } catch (e) {
+    const r = fromError(e);
+    if (r) return r;
+    throw e;
+  }
+
+  const { id } = await ctx.params;
+  if (!isUuid(id)) return NextResponse.json({ error: "invalid id" }, { status: 400 });
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "VALIDATION_FAILED", errors: [{ field: "body", message: "invalid JSON" }] },
+      { status: 400 },
+    );
+  }
+
+  const result = validateUserActivityPatch(body);
+  if (!result.ok) {
+    return NextResponse.json({ error: "VALIDATION_FAILED", errors: result.errors }, { status: 400 });
+  }
+  const patch = result.value;
+
+  const owned = await loadOwned(id, me.id);
+  if (!owned) return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
+
+  // Apply each provided field individually. Tagged-template SQL doesn't
+  // compose dynamic SET lists cleanly, so the four-field permutation runs
+  // as separate UPDATEs in a single transaction.
+  if (patch.skillLevel !== undefined) {
+    await sql`UPDATE hap_user_activities SET skill_level = ${patch.skillLevel} WHERE id = ${id}`;
+  }
+  if (patch.frequency !== undefined) {
+    await sql`UPDATE hap_user_activities SET frequency = ${patch.frequency} WHERE id = ${id}`;
+  }
+  if (patch.timeWindows !== undefined) {
+    await sql`UPDATE hap_user_activities SET time_windows = ${patch.timeWindows as unknown as string[]} WHERE id = ${id}`;
+  }
+  if (patch.locationRadius !== undefined) {
+    await sql`UPDATE hap_user_activities SET location_radius = ${patch.locationRadius} WHERE id = ${id}`;
+  }
+  if (patch.notes !== undefined) {
+    await sql`UPDATE hap_user_activities SET notes = ${patch.notes} WHERE id = ${id}`;
+  }
+
+  return NextResponse.json({ id });
+}
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  let me;
+  try {
+    me = await requireHapUser();
+  } catch (e) {
+    const r = fromError(e);
+    if (r) return r;
+    throw e;
+  }
+
+  const { id } = await ctx.params;
+  if (!isUuid(id)) return NextResponse.json({ error: "invalid id" }, { status: 400 });
+
+  const owned = await loadOwned(id, me.id);
+  if (!owned) return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
+
+  await sql`UPDATE hap_user_activities SET is_active = false WHERE id = ${id}`;
+  return NextResponse.json({ id, deactivated: true });
+}

--- a/apps/hive-activity-partner/app/api/users/me/activities/route.ts
+++ b/apps/hive-activity-partner/app/api/users/me/activities/route.ts
@@ -1,0 +1,156 @@
+// GET /api/users/me/activities — list the signed-in user's active activity rows,
+// joined with the taxonomy slug + display_name + category so the frontend can
+// render cards without a second round-trip.
+//
+// POST /api/users/me/activities — add a new activity for the signed-in user.
+// Validates against hap_activity_taxonomy (must be active and not pending).
+// Idempotent on (user_id, activity_id) thanks to the partial unique index;
+// re-adding a previously-deactivated row reactivates it.
+
+import { NextResponse } from "next/server";
+import { sql } from "@/lib/db";
+import { requireHapUser } from "@/lib/auth";
+import { stripForbidden } from "@/lib/profile";
+import { validateUserActivity } from "@/lib/validation/activity";
+
+export const dynamic = "force-dynamic";
+
+type ListRow = {
+  id: string;
+  activity_id: string;
+  slug: string;
+  display_name: string;
+  category: string;
+  skill_level: string;
+  frequency: string;
+  time_windows: string[];
+  location_radius: string;
+  notes: string | null;
+  created_at: string;
+};
+
+function fromError(e: unknown): NextResponse | null {
+  const status = (e as { status?: number })?.status;
+  if (status === 401) return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  if (status === 403) return NextResponse.json({ error: "SUSPENDED" }, { status: 403 });
+  if (status === 404) return NextResponse.json({ error: "PROFILE_REQUIRED" }, { status: 404 });
+  return null;
+}
+
+export async function GET() {
+  let me;
+  try {
+    me = await requireHapUser();
+  } catch (e) {
+    const r = fromError(e);
+    if (r) return r;
+    throw e;
+  }
+
+  const rows = (await sql`
+    SELECT ua.id, ua.activity_id, t.slug, t.display_name, t.category,
+           ua.skill_level, ua.frequency, ua.time_windows, ua.location_radius,
+           ua.notes, ua.created_at
+    FROM hap_user_activities ua
+    JOIN hap_activity_taxonomy t ON t.id = ua.activity_id
+    WHERE ua.user_id = ${me.id} AND ua.is_active = true
+    ORDER BY ua.created_at DESC
+  `) as ListRow[];
+
+  return NextResponse.json({
+    activities: rows.map((r) =>
+      stripForbidden({
+        id: r.id,
+        activityId: r.activity_id,
+        slug: r.slug,
+        displayName: r.display_name,
+        category: r.category,
+        skillLevel: r.skill_level,
+        frequency: r.frequency,
+        timeWindows: r.time_windows,
+        locationRadius: r.location_radius,
+        notes: r.notes,
+        createdAt: r.created_at,
+      }),
+    ),
+  });
+}
+
+export async function POST(req: Request) {
+  let me;
+  try {
+    me = await requireHapUser();
+  } catch (e) {
+    const r = fromError(e);
+    if (r) return r;
+    throw e;
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "VALIDATION_FAILED", errors: [{ field: "body", message: "invalid JSON" }] },
+      { status: 400 },
+    );
+  }
+
+  const result = validateUserActivity(body);
+  if (!result.ok) {
+    return NextResponse.json({ error: "VALIDATION_FAILED", errors: result.errors }, { status: 400 });
+  }
+  const v = result.value;
+
+  // Confirm the activity exists, is active, and isn't pending moderation.
+  const taxonomy = (await sql`
+    SELECT id, is_active, is_pending_moderation
+    FROM hap_activity_taxonomy
+    WHERE id = ${v.activityId}
+    LIMIT 1
+  `) as Array<{ id: string; is_active: boolean; is_pending_moderation: boolean }>;
+  if (taxonomy.length === 0) {
+    return NextResponse.json({ error: "ACTIVITY_NOT_FOUND" }, { status: 404 });
+  }
+  if (!taxonomy[0].is_active || taxonomy[0].is_pending_moderation) {
+    return NextResponse.json({ error: "ACTIVITY_NOT_AVAILABLE" }, { status: 409 });
+  }
+
+  // If the user previously deactivated this same activity, reactivate that row
+  // so we don't accumulate dead rows. Otherwise insert a fresh row.
+  const existing = (await sql`
+    SELECT id FROM hap_user_activities
+    WHERE user_id = ${me.id} AND activity_id = ${v.activityId}
+    ORDER BY created_at DESC
+    LIMIT 1
+  `) as Array<{ id: string }>;
+
+  let rowId: string;
+  if (existing.length > 0) {
+    const updated = (await sql`
+      UPDATE hap_user_activities
+      SET skill_level = ${v.skillLevel},
+          frequency = ${v.frequency},
+          time_windows = ${v.timeWindows as unknown as string[]},
+          location_radius = ${v.locationRadius},
+          notes = ${v.notes},
+          is_active = true
+      WHERE id = ${existing[0].id}
+      RETURNING id
+    `) as Array<{ id: string }>;
+    rowId = updated[0].id;
+  } else {
+    const inserted = (await sql`
+      INSERT INTO hap_user_activities (
+        user_id, activity_id, skill_level, frequency, time_windows, location_radius, notes
+      ) VALUES (
+        ${me.id}, ${v.activityId}, ${v.skillLevel}, ${v.frequency},
+        ${v.timeWindows as unknown as string[]}, ${v.locationRadius}, ${v.notes}
+      )
+      RETURNING id
+    `) as Array<{ id: string }>;
+    rowId = inserted[0].id;
+  }
+
+  return NextResponse.json({ id: rowId }, { status: 201 });
+}

--- a/apps/hive-activity-partner/db/schema/010_hap_moderation_log.sql
+++ b/apps/hive-activity-partner/db/schema/010_hap_moderation_log.sql
@@ -1,0 +1,16 @@
+-- HiveActivityPartner — moderation log for user-requested activities.
+-- Phase 2 active. Every approve/reject on hap_activity_taxonomy rows where
+-- is_pending_moderation=true writes a row here for audit + appeal purposes.
+
+CREATE TABLE IF NOT EXISTS hap_moderation_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  taxonomy_id UUID NOT NULL REFERENCES hap_activity_taxonomy(id) ON DELETE CASCADE,
+  decision TEXT NOT NULL CHECK (decision IN ('approved', 'rejected', 'archived')),
+  reason TEXT CHECK (reason IS NULL OR length(reason) <= 500),
+  moderator_identity TEXT NOT NULL,
+  request_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hap_moderation_log_taxonomy ON hap_moderation_log(taxonomy_id);
+CREATE INDEX IF NOT EXISTS idx_hap_moderation_log_created ON hap_moderation_log(created_at DESC);

--- a/apps/hive-activity-partner/db/schema/011_seed_activity_taxonomy.sql
+++ b/apps/hive-activity-partner/db/schema/011_seed_activity_taxonomy.sql
@@ -1,0 +1,112 @@
+-- HiveActivityPartner — taxonomy seed (Phase 2).
+-- 89 canonical activities anchored to apps/hive-activity-partner/locales/en.json
+-- "activities" object. Slugs are camelCase to match the locale key 1:1, so the
+-- frontend can do `t.activities[slug]` without a slug→key mapping.
+--
+-- Idempotent via ON CONFLICT (slug) DO NOTHING. Re-running is safe; rows the
+-- operator has manually edited (e.g., recategorised) are NOT overwritten.
+-- Display name carries the English label; localisation happens at the UI layer
+-- via locales/<lang>.json.
+
+INSERT INTO hap_activity_taxonomy (slug, display_name, category, is_active, is_pending_moderation) VALUES
+  -- sport (25)
+  ('tennis', 'Tennis', 'sport', true, false),
+  ('badminton', 'Badminton', 'sport', true, false),
+  ('padel', 'Padel', 'sport', true, false),
+  ('tableTennis', 'Table tennis', 'sport', true, false),
+  ('squash', 'Squash', 'sport', true, false),
+  ('basketball', 'Basketball', 'sport', true, false),
+  ('football', 'Football (soccer)', 'sport', true, false),
+  ('futsal', 'Futsal', 'sport', true, false),
+  ('americanFootball', 'American football', 'sport', true, false),
+  ('baseball', 'Baseball', 'sport', true, false),
+  ('softball', 'Softball', 'sport', true, false),
+  ('cricket', 'Cricket', 'sport', true, false),
+  ('rugby', 'Rugby', 'sport', true, false),
+  ('fieldHockey', 'Field hockey', 'sport', true, false),
+  ('iceHockey', 'Ice hockey', 'sport', true, false),
+  ('lacrosse', 'Lacrosse', 'sport', true, false),
+  ('volleyball', 'Volleyball', 'sport', true, false),
+  ('beachVolleyball', 'Beach volleyball', 'sport', true, false),
+  ('ultimateFrisbee', 'Ultimate frisbee', 'sport', true, false),
+  ('golf', 'Golf', 'sport', true, false),
+  ('swimming', 'Swimming', 'sport', true, false),
+  ('waterPolo', 'Water polo', 'sport', true, false),
+  ('surfing', 'Surfing', 'sport', true, false),
+  ('sailing', 'Sailing', 'sport', true, false),
+  ('rowing', 'Rowing', 'sport', true, false),
+
+  -- fitness (14)
+  ('running', 'Running', 'fitness', true, false),
+  ('jogging', 'Jogging', 'fitness', true, false),
+  ('gymWorkout', 'Gym workout', 'fitness', true, false),
+  ('weightlifting', 'Weightlifting', 'fitness', true, false),
+  ('crossfit', 'CrossFit', 'fitness', true, false),
+  ('yoga', 'Yoga', 'fitness', true, false),
+  ('pilates', 'Pilates', 'fitness', true, false),
+  ('climbing', 'Climbing', 'fitness', true, false),
+  ('bouldering', 'Bouldering', 'fitness', true, false),
+  ('dancing', 'Dancing', 'fitness', true, false),
+  ('martialArts', 'Martial arts', 'fitness', true, false),
+  ('boxing', 'Boxing', 'fitness', true, false),
+  ('mma', 'MMA', 'fitness', true, false),
+  ('kickboxing', 'Kickboxing', 'fitness', true, false),
+
+  -- outdoor (13)
+  ('walking', 'Walking', 'outdoor', true, false),
+  ('hiking', 'Hiking', 'outdoor', true, false),
+  ('cycling', 'Cycling', 'outdoor', true, false),
+  ('mountainBiking', 'Mountain biking', 'outdoor', true, false),
+  ('birdWatching', 'Bird watching', 'outdoor', true, false),
+  ('gardening', 'Gardening', 'outdoor', true, false),
+  ('fishing', 'Fishing', 'outdoor', true, false),
+  ('camping', 'Camping', 'outdoor', true, false),
+  ('picnic', 'Picnic', 'outdoor', true, false),
+  ('kayaking', 'Kayaking', 'outdoor', true, false),
+  ('paddleboarding', 'Paddleboarding', 'outdoor', true, false),
+  ('skiing', 'Skiing', 'outdoor', true, false),
+  ('snowboarding', 'Snowboarding', 'outdoor', true, false),
+
+  -- creative (18)
+  ('lifeDrawing', 'Life drawing', 'creative', true, false),
+  ('painting', 'Painting', 'creative', true, false),
+  ('sketching', 'Sketching', 'creative', true, false),
+  ('photography', 'Photography', 'creative', true, false),
+  ('pottery', 'Pottery', 'creative', true, false),
+  ('ceramics', 'Ceramics', 'creative', true, false),
+  ('knitting', 'Knitting', 'creative', true, false),
+  ('crochet', 'Crochet', 'creative', true, false),
+  ('sewing', 'Sewing', 'creative', true, false),
+  ('woodworking', 'Woodworking', 'creative', true, false),
+  ('jewelryMaking', 'Jewelry making', 'creative', true, false),
+  ('calligraphy', 'Calligraphy', 'creative', true, false),
+  ('songwriting', 'Songwriting', 'creative', true, false),
+  ('musicJamming', 'Music jamming', 'creative', true, false),
+  ('choir', 'Choir', 'creative', true, false),
+  ('bandPractice', 'Band practice', 'creative', true, false),
+  ('theater', 'Theater', 'creative', true, false),
+  ('improv', 'Improv', 'creative', true, false),
+
+  -- intellectual (11)
+  ('chess', 'Chess', 'intellectual', true, false),
+  ('go', 'Go', 'intellectual', true, false),
+  ('scrabble', 'Scrabble', 'intellectual', true, false),
+  ('boardGames', 'Board games', 'intellectual', true, false),
+  ('languageExchange', 'Language exchange', 'intellectual', true, false),
+  ('studySession', 'Study session', 'intellectual', true, false),
+  ('bookClub', 'Book club', 'intellectual', true, false),
+  ('philosophyDiscussion', 'Philosophy discussion', 'intellectual', true, false),
+  ('debate', 'Debate', 'intellectual', true, false),
+  ('pairProgramming', 'Pair programming', 'intellectual', true, false),
+  ('trivia', 'Trivia', 'intellectual', true, false),
+
+  -- social (8)
+  ('coffeeChat', 'Coffee chat', 'social', true, false),
+  ('brunch', 'Brunch', 'social', true, false),
+  ('dinner', 'Dinner', 'social', true, false),
+  ('movieNight', 'Movie night', 'social', true, false),
+  ('museumVisit', 'Museum visit', 'social', true, false),
+  ('galleryVisit', 'Gallery visit', 'social', true, false),
+  ('concert', 'Concert', 'social', true, false),
+  ('gig', 'Gig', 'social', true, false)
+ON CONFLICT (slug) DO NOTHING;

--- a/apps/hive-activity-partner/db/schema/012_hap_operator_audit.sql
+++ b/apps/hive-activity-partner/db/schema/012_hap_operator_audit.sql
@@ -1,0 +1,18 @@
+-- HiveActivityPartner — operator action audit log per Constitution §V.
+-- Every operator-flagged write across the engine writes a row here. Read
+-- queries do NOT log unless they touch sensitive surfaces.
+
+CREATE TABLE IF NOT EXISTS hap_operator_audit (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_identity TEXT NOT NULL,
+  action TEXT NOT NULL,
+  engine_slug TEXT NOT NULL DEFAULT 'hive-activity-partner',
+  target_id TEXT,
+  target_type TEXT,
+  request_id TEXT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hap_operator_audit_identity ON hap_operator_audit(user_identity, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_hap_operator_audit_action ON hap_operator_audit(action, created_at DESC);

--- a/apps/hive-activity-partner/db/schema/013_hap_operator_setup_code_state.sql
+++ b/apps/hive-activity-partner/db/schema/013_hap_operator_setup_code_state.sql
@@ -1,0 +1,15 @@
+-- HiveActivityPartner — single-use bootstrap code state for operator login.
+-- The OPERATOR_SETUP_CODE env var is only valid until used once; this table
+-- tracks the consumed-codes hash so a leaked .env can't replay.
+--
+-- The operator rotates OPERATOR_SETUP_CODE after each successful use. Codes
+-- are stored as SHA-256 of the raw code so the table itself isn't a secret.
+
+CREATE TABLE IF NOT EXISTS hap_operator_setup_code_state (
+  code_hash TEXT PRIMARY KEY,
+  consumed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  consumed_by_identity TEXT NOT NULL,
+  request_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_hap_operator_setup_code_consumed ON hap_operator_setup_code_state(consumed_at DESC);

--- a/apps/hive-activity-partner/lib/auth.ts
+++ b/apps/hive-activity-partner/lib/auth.ts
@@ -62,3 +62,27 @@ export async function requireClerkUser(): Promise<ClerkUserSummary> {
   }
   return u;
 }
+
+// Throws 401 if not signed in, 404 if signed in but hap_users row not yet
+// created (user hasn't finished POST /api/users). Suspended users get a 403
+// so they see a distinct error from "no profile yet".
+export async function requireHapUser(): Promise<HapUserRow> {
+  const me = await getHapUser();
+  if (!me) {
+    const clerk = await getClerkUser();
+    if (!clerk) {
+      const err = new Error("UNAUTHENTICATED");
+      (err as Error & { status?: number }).status = 401;
+      throw err;
+    }
+    const err = new Error("HAP_PROFILE_REQUIRED");
+    (err as Error & { status?: number }).status = 404;
+    throw err;
+  }
+  if (me.is_suspended) {
+    const err = new Error("HAP_USER_SUSPENDED");
+    (err as Error & { status?: number }).status = 403;
+    throw err;
+  }
+  return me;
+}

--- a/apps/hive-activity-partner/lib/db-operator.ts
+++ b/apps/hive-activity-partner/lib/db-operator.ts
@@ -1,0 +1,33 @@
+// Operator-flagged DB operations + audit logging.
+// Wrap any operator-side write through `auditOperatorAction` so the
+// hap_operator_audit table records who did what, when, and why. Read-only
+// operator queries don't audit unless they touch sensitive surfaces.
+
+import { sql } from "./db";
+import type { OperatorIdentity } from "./operator-auth";
+
+export type OperatorAuditEvent = {
+  identity: OperatorIdentity;
+  action: string;
+  targetId?: string | null;
+  targetType?: string | null;
+  requestId?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export async function auditOperatorAction(event: OperatorAuditEvent): Promise<void> {
+  const metadataJson = event.metadata ? JSON.stringify(event.metadata) : null;
+  await sql`
+    INSERT INTO hap_operator_audit (
+      user_identity, action, engine_slug, target_id, target_type, request_id, metadata
+    ) VALUES (
+      ${event.identity.identity},
+      ${event.action},
+      'hive-activity-partner',
+      ${event.targetId ?? null},
+      ${event.targetType ?? null},
+      ${event.requestId ?? null},
+      ${metadataJson}::jsonb
+    )
+  `;
+}

--- a/apps/hive-activity-partner/lib/operator-auth.ts
+++ b/apps/hive-activity-partner/lib/operator-auth.ts
@@ -1,0 +1,139 @@
+// Operator role per Constitution §V. Three valid markers, in priority order:
+//
+//   1. Clerk publicMetadata.role === 'operator' on the signed-in user.
+//   2. Signed cookie hap_operator (HMAC-SHA256 with OPERATOR_AUTH_SECRET, 30-day TTL).
+//   3. Header x-hap-operator-key matching OPERATOR_KEY (constant-time compared).
+//
+// Any operator-flagged action MUST log to hap_operator_audit via lib/db-operator.ts.
+// The operator role is for testing, debugging, and emergency access. Never expose
+// it in UI, pricing, or marketing copy.
+
+import { createHmac, timingSafeEqual, createHash, randomBytes } from "node:crypto";
+import { cookies } from "next/headers";
+import { currentUser } from "@clerk/nextjs/server";
+
+export const OPERATOR_COOKIE_NAME = "hap_operator";
+export const OPERATOR_HEADER_NAME = "x-hap-operator-key";
+export const OPERATOR_COOKIE_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+export type OperatorIdentity = {
+  marker: "clerk" | "cookie" | "header";
+  identity: string;
+};
+
+function getSecret(name: "OPERATOR_AUTH_SECRET" | "OPERATOR_KEY"): string | null {
+  const v = process.env[name];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function constantTimeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+// Cookie value: <issuedAtMs>.<identity-base64url>.<sig-base64url>
+// sig = HMAC-SHA256(OPERATOR_AUTH_SECRET, "<issuedAtMs>.<identity-base64url>")
+function signCookieValue(identity: string, issuedAtMs: number, secret: string): string {
+  const idEncoded = Buffer.from(identity, "utf8").toString("base64url");
+  const payload = `${issuedAtMs}.${idEncoded}`;
+  const sig = createHmac("sha256", secret).update(payload).digest("base64url");
+  return `${payload}.${sig}`;
+}
+
+export function issueOperatorCookieValue(identity: string): string | null {
+  const secret = getSecret("OPERATOR_AUTH_SECRET");
+  if (!secret) return null;
+  return signCookieValue(identity, Date.now(), secret);
+}
+
+export function verifyOperatorCookieValue(
+  raw: string,
+): { identity: string } | null {
+  const secret = getSecret("OPERATOR_AUTH_SECRET");
+  if (!secret) return null;
+  const parts = raw.split(".");
+  if (parts.length !== 3) return null;
+  const [issuedAtStr, idEncoded, providedSig] = parts;
+  const issuedAt = Number(issuedAtStr);
+  if (!Number.isFinite(issuedAt)) return null;
+  if (Date.now() - issuedAt > OPERATOR_COOKIE_TTL_SECONDS * 1000) return null;
+  const expectedSig = createHmac("sha256", secret)
+    .update(`${issuedAtStr}.${idEncoded}`)
+    .digest("base64url");
+  if (!constantTimeStringEqual(providedSig, expectedSig)) return null;
+  let identity: string;
+  try {
+    identity = Buffer.from(idEncoded, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+  if (!identity) return null;
+  return { identity };
+}
+
+// Returns the operator identity (and which marker matched) or null. The header
+// path takes precedence for CLI use; Clerk overrides cookie when present so a
+// signed-in operator's identity is the canonical Clerk user id.
+export async function detectOperator(req: Request): Promise<OperatorIdentity | null> {
+  // 1) Clerk metadata
+  try {
+    const u = await currentUser();
+    const role = (u?.publicMetadata as { role?: unknown } | undefined)?.role;
+    if (u && role === "operator") {
+      return { marker: "clerk", identity: `clerk:${u.id}` };
+    }
+  } catch {
+    // currentUser() can throw outside an authenticated request; fall through.
+  }
+
+  // 2) Header (CLI / automation)
+  const headerKey = req.headers.get(OPERATOR_HEADER_NAME);
+  const expectedHeader = getSecret("OPERATOR_KEY");
+  if (headerKey && expectedHeader && constantTimeStringEqual(headerKey, expectedHeader)) {
+    return { marker: "header", identity: "header:cli" };
+  }
+
+  // 3) Signed cookie
+  const cookieJar = await cookies();
+  const cookieRaw = cookieJar.get(OPERATOR_COOKIE_NAME)?.value;
+  if (cookieRaw) {
+    const verified = verifyOperatorCookieValue(cookieRaw);
+    if (verified) {
+      return { marker: "cookie", identity: `cookie:${verified.identity}` };
+    }
+  }
+
+  return null;
+}
+
+// Throws a 401-flavoured Error if the request is not from an operator.
+export async function requireOperator(req: Request): Promise<OperatorIdentity> {
+  const op = await detectOperator(req);
+  if (!op) {
+    const err = new Error("OPERATOR_REQUIRED");
+    (err as Error & { status?: number }).status = 401;
+    throw err;
+  }
+  return op;
+}
+
+// Hash the OPERATOR_SETUP_CODE for consumed-codes lookup. Storing the hash
+// (not the code) means even DB read access can't replay the bootstrap.
+export function hashSetupCode(code: string): string {
+  return createHash("sha256").update(code, "utf8").digest("hex");
+}
+
+export function getConfiguredSetupCode(): string | null {
+  return getSecret("OPERATOR_AUTH_SECRET") ? process.env.OPERATOR_SETUP_CODE ?? null : null;
+}
+
+// Constant-time setup-code compare; both args are user input.
+export function setupCodeMatches(provided: string, configured: string): boolean {
+  return constantTimeStringEqual(provided, configured);
+}
+
+export function newRequestId(): string {
+  return randomBytes(8).toString("hex");
+}

--- a/apps/hive-activity-partner/lib/validation/activity.ts
+++ b/apps/hive-activity-partner/lib/validation/activity.ts
@@ -1,0 +1,275 @@
+// Validation for hap_user_activities + hap_activity_taxonomy inputs.
+// Mirrors the Postgres CHECK constraints in db/schema/004 and 003 so we
+// surface friendly errors instead of letting the DB reject. Also covers
+// the time_windows array shape, which Postgres treats as a free TEXT[].
+
+export const SKILL_LEVELS = ["beginner", "intermediate", "advanced", "any"] as const;
+export type SkillLevel = (typeof SKILL_LEVELS)[number];
+
+export const FREQUENCIES = ["one_time", "weekly", "flexible"] as const;
+export type Frequency = (typeof FREQUENCIES)[number];
+
+export const LOCATION_RADII = ["walk", "bike", "transit", "drive"] as const;
+export type LocationRadius = (typeof LOCATION_RADII)[number];
+
+export const CATEGORIES = [
+  "sport",
+  "fitness",
+  "creative",
+  "intellectual",
+  "outdoor",
+  "social",
+] as const;
+export type Category = (typeof CATEGORIES)[number];
+
+export const TIME_WINDOWS = [
+  "weekday_morning",
+  "weekday_afternoon",
+  "weekday_evening",
+  "weekend_morning",
+  "weekend_afternoon",
+  "weekend_evening",
+  "late_night",
+] as const;
+export type TimeWindow = (typeof TIME_WINDOWS)[number];
+
+export const NOTES_MAX = 500;
+export const REQUEST_JUSTIFICATION_MAX = 500;
+export const REQUEST_DISPLAY_NAME_MAX = 60;
+export const REQUEST_SLUG_MAX = 40;
+
+export type ValidationError = { field: string; message: string };
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; errors: ValidationError[] };
+
+function err(field: string, message: string): ValidationError {
+  return { field, message };
+}
+
+export type UserActivityInput = {
+  activityId: string;
+  skillLevel: SkillLevel;
+  frequency: Frequency;
+  timeWindows: TimeWindow[];
+  locationRadius: LocationRadius;
+  notes: string | null;
+};
+
+export function validateUserActivity(raw: unknown): ValidationResult<UserActivityInput> {
+  const errors: ValidationError[] = [];
+  const body = (raw ?? {}) as Record<string, unknown>;
+
+  const activityId = typeof body.activityId === "string" ? body.activityId.trim() : "";
+  if (!activityId || !isUuid(activityId)) {
+    errors.push(err("activityId", "must be a valid taxonomy id"));
+  }
+
+  const skillLevel = body.skillLevel;
+  if (!isSkillLevel(skillLevel)) {
+    errors.push(err("skillLevel", `must be one of: ${SKILL_LEVELS.join(", ")}`));
+  }
+
+  const frequency = body.frequency;
+  if (!isFrequency(frequency)) {
+    errors.push(err("frequency", `must be one of: ${FREQUENCIES.join(", ")}`));
+  }
+
+  const timeWindowsRaw = body.timeWindows;
+  let timeWindows: TimeWindow[] = [];
+  if (!Array.isArray(timeWindowsRaw) || timeWindowsRaw.length === 0) {
+    errors.push(err("timeWindows", "pick at least one time window"));
+  } else {
+    const filtered = timeWindowsRaw.filter(isTimeWindow);
+    if (filtered.length !== timeWindowsRaw.length) {
+      errors.push(
+        err("timeWindows", `unknown time window; valid: ${TIME_WINDOWS.join(", ")}`),
+      );
+    }
+    timeWindows = Array.from(new Set(filtered));
+  }
+
+  const locationRadius = body.locationRadius;
+  if (!isLocationRadius(locationRadius)) {
+    errors.push(err("locationRadius", `must be one of: ${LOCATION_RADII.join(", ")}`));
+  }
+
+  let notes: string | null = null;
+  if (body.notes !== undefined && body.notes !== null) {
+    if (typeof body.notes !== "string") {
+      errors.push(err("notes", "must be a string"));
+    } else {
+      const trimmed = body.notes.trim();
+      if (trimmed.length > NOTES_MAX) {
+        errors.push(err("notes", `must be ${NOTES_MAX} characters or fewer`));
+      } else {
+        notes = trimmed.length === 0 ? null : trimmed;
+      }
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    value: {
+      activityId,
+      skillLevel: skillLevel as SkillLevel,
+      frequency: frequency as Frequency,
+      timeWindows,
+      locationRadius: locationRadius as LocationRadius,
+      notes,
+    },
+  };
+}
+
+export type UserActivityPatch = Partial<Omit<UserActivityInput, "activityId">>;
+
+export function validateUserActivityPatch(raw: unknown): ValidationResult<UserActivityPatch> {
+  const errors: ValidationError[] = [];
+  const body = (raw ?? {}) as Record<string, unknown>;
+  const patch: UserActivityPatch = {};
+
+  if (body.skillLevel !== undefined) {
+    if (!isSkillLevel(body.skillLevel)) {
+      errors.push(err("skillLevel", `must be one of: ${SKILL_LEVELS.join(", ")}`));
+    } else {
+      patch.skillLevel = body.skillLevel;
+    }
+  }
+
+  if (body.frequency !== undefined) {
+    if (!isFrequency(body.frequency)) {
+      errors.push(err("frequency", `must be one of: ${FREQUENCIES.join(", ")}`));
+    } else {
+      patch.frequency = body.frequency;
+    }
+  }
+
+  if (body.timeWindows !== undefined) {
+    if (!Array.isArray(body.timeWindows) || body.timeWindows.length === 0) {
+      errors.push(err("timeWindows", "pick at least one time window"));
+    } else {
+      const filtered = body.timeWindows.filter(isTimeWindow);
+      if (filtered.length !== body.timeWindows.length) {
+        errors.push(
+          err("timeWindows", `unknown time window; valid: ${TIME_WINDOWS.join(", ")}`),
+        );
+      } else {
+        patch.timeWindows = Array.from(new Set(filtered));
+      }
+    }
+  }
+
+  if (body.locationRadius !== undefined) {
+    if (!isLocationRadius(body.locationRadius)) {
+      errors.push(err("locationRadius", `must be one of: ${LOCATION_RADII.join(", ")}`));
+    } else {
+      patch.locationRadius = body.locationRadius;
+    }
+  }
+
+  if (body.notes !== undefined) {
+    if (body.notes === null) {
+      patch.notes = null;
+    } else if (typeof body.notes !== "string") {
+      errors.push(err("notes", "must be a string"));
+    } else {
+      const trimmed = body.notes.trim();
+      if (trimmed.length > NOTES_MAX) {
+        errors.push(err("notes", `must be ${NOTES_MAX} characters or fewer`));
+      } else {
+        patch.notes = trimmed.length === 0 ? null : trimmed;
+      }
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  if (Object.keys(patch).length === 0) {
+    return { ok: false, errors: [err("body", "no updatable fields provided")] };
+  }
+  return { ok: true, value: patch };
+}
+
+export type ActivityRequestInput = {
+  slug: string;
+  displayName: string;
+  category: Category;
+  justification: string;
+};
+
+export function validateActivityRequest(
+  raw: unknown,
+): ValidationResult<ActivityRequestInput> {
+  const errors: ValidationError[] = [];
+  const body = (raw ?? {}) as Record<string, unknown>;
+
+  const slugRaw = typeof body.slug === "string" ? body.slug.trim() : "";
+  if (!slugRaw) {
+    errors.push(err("slug", "is required"));
+  } else if (slugRaw.length > REQUEST_SLUG_MAX) {
+    errors.push(err("slug", `must be ${REQUEST_SLUG_MAX} characters or fewer`));
+  } else if (!/^[a-z][a-zA-Z0-9]*$/.test(slugRaw)) {
+    errors.push(err("slug", "must be camelCase, starting with a lowercase letter"));
+  }
+
+  const displayName = typeof body.displayName === "string" ? body.displayName.trim() : "";
+  if (!displayName) {
+    errors.push(err("displayName", "is required"));
+  } else if (displayName.length > REQUEST_DISPLAY_NAME_MAX) {
+    errors.push(
+      err("displayName", `must be ${REQUEST_DISPLAY_NAME_MAX} characters or fewer`),
+    );
+  }
+
+  const category = body.category;
+  if (!isCategory(category)) {
+    errors.push(err("category", `must be one of: ${CATEGORIES.join(", ")}`));
+  }
+
+  const justification = typeof body.justification === "string" ? body.justification.trim() : "";
+  if (!justification) {
+    errors.push(err("justification", "is required"));
+  } else if (justification.length > REQUEST_JUSTIFICATION_MAX) {
+    errors.push(
+      err("justification", `must be ${REQUEST_JUSTIFICATION_MAX} characters or fewer`),
+    );
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    value: {
+      slug: slugRaw,
+      displayName,
+      category: category as Category,
+      justification,
+    },
+  };
+}
+
+export function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+  );
+}
+
+export function isSkillLevel(value: unknown): value is SkillLevel {
+  return typeof value === "string" && (SKILL_LEVELS as readonly string[]).includes(value);
+}
+
+export function isFrequency(value: unknown): value is Frequency {
+  return typeof value === "string" && (FREQUENCIES as readonly string[]).includes(value);
+}
+
+export function isTimeWindow(value: unknown): value is TimeWindow {
+  return typeof value === "string" && (TIME_WINDOWS as readonly string[]).includes(value);
+}
+
+export function isLocationRadius(value: unknown): value is LocationRadius {
+  return typeof value === "string" && (LOCATION_RADII as readonly string[]).includes(value);
+}
+
+export function isCategory(value: unknown): value is Category {
+  return typeof value === "string" && (CATEGORIES as readonly string[]).includes(value);
+}

--- a/apps/hive-activity-partner/package-lock.json
+++ b/apps/hive-activity-partner/package-lock.json
@@ -18,6 +18,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "tsx": "^4.19.0",
         "typescript": "^5"
       }
     },
@@ -125,6 +126,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@img/colour": {
@@ -921,11 +1364,81 @@
         "node": ">=8"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
@@ -1161,6 +1674,16 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -1297,6 +1820,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/apps/hive-activity-partner/package.json
+++ b/apps/hive-activity-partner/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "tsx --test test/*.test.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "next": "16.2.3",
@@ -18,6 +20,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "tsx": "^4.19.0",
     "typescript": "^5"
   }
 }

--- a/apps/hive-activity-partner/test/operator-auth.test.ts
+++ b/apps/hive-activity-partner/test/operator-auth.test.ts
@@ -1,0 +1,68 @@
+// Pure-function tests for lib/operator-auth.ts. The Clerk + cookies()
+// integration is exercised at the route level; here we verify the HMAC
+// signing, cookie verification, hash function, and constant-time setup
+// code compare behave as expected without hitting Next.js runtime.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  hashSetupCode,
+  setupCodeMatches,
+  issueOperatorCookieValue,
+  verifyOperatorCookieValue,
+  OPERATOR_COOKIE_TTL_SECONDS,
+} from "../lib/operator-auth";
+
+test("hashSetupCode is stable + length 64 hex", () => {
+  const a = hashSetupCode("123456");
+  const b = hashSetupCode("123456");
+  assert.equal(a, b);
+  assert.equal(a.length, 64);
+  assert.match(a, /^[0-9a-f]{64}$/);
+
+  const c = hashSetupCode("123457");
+  assert.notEqual(a, c);
+});
+
+test("setupCodeMatches — equal and unequal both run constant-time", () => {
+  assert.equal(setupCodeMatches("123456", "123456"), true);
+  assert.equal(setupCodeMatches("123456", "654321"), false);
+  // Different lengths must short-circuit to false safely (not throw).
+  assert.equal(setupCodeMatches("12345", "123456"), false);
+});
+
+test("issueOperatorCookieValue + verifyOperatorCookieValue round-trip", () => {
+  process.env.OPERATOR_AUTH_SECRET = "test-secret-not-real";
+  const value = issueOperatorCookieValue("u_123");
+  assert.ok(value, "cookie value should be issued when OPERATOR_AUTH_SECRET is set");
+  const verified = verifyOperatorCookieValue(value!);
+  assert.ok(verified);
+  assert.equal(verified!.identity, "u_123");
+});
+
+test("verifyOperatorCookieValue rejects tampered cookies", () => {
+  process.env.OPERATOR_AUTH_SECRET = "test-secret-not-real";
+  const value = issueOperatorCookieValue("u_123");
+  assert.ok(value);
+  const tampered = value!.replace(/.$/, (c) => (c === "A" ? "B" : "A"));
+  assert.equal(verifyOperatorCookieValue(tampered), null);
+});
+
+test("verifyOperatorCookieValue rejects expired cookies", async () => {
+  process.env.OPERATOR_AUTH_SECRET = "test-secret-not-real";
+  // Manually craft a cookie issued > TTL ago.
+  const issuedAt = Date.now() - (OPERATOR_COOKIE_TTL_SECONDS + 60) * 1000;
+  const idEncoded = Buffer.from("u_123", "utf8").toString("base64url");
+  const { createHmac } = await import("node:crypto");
+  const sig = createHmac("sha256", "test-secret-not-real")
+    .update(`${issuedAt}.${idEncoded}`)
+    .digest("base64url");
+  const expired = `${issuedAt}.${idEncoded}.${sig}`;
+  assert.equal(verifyOperatorCookieValue(expired), null);
+});
+
+test("issueOperatorCookieValue returns null when secret is missing", () => {
+  delete process.env.OPERATOR_AUTH_SECRET;
+  assert.equal(issueOperatorCookieValue("u_123"), null);
+});

--- a/apps/hive-activity-partner/test/validation.test.ts
+++ b/apps/hive-activity-partner/test/validation.test.ts
@@ -1,0 +1,227 @@
+// Pure-function unit tests for lib/validation/activity.ts. Run via:
+//   npm test            (uses node --test + tsx loader)
+//
+// Covers the happy path and the error cases the API routes depend on.
+// Route-level integration tests live elsewhere (require Neon + Clerk).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  validateUserActivity,
+  validateUserActivityPatch,
+  validateActivityRequest,
+  isUuid,
+  isSkillLevel,
+  isFrequency,
+  isTimeWindow,
+  isLocationRadius,
+  isCategory,
+  NOTES_MAX,
+  REQUEST_DISPLAY_NAME_MAX,
+  REQUEST_JUSTIFICATION_MAX,
+  REQUEST_SLUG_MAX,
+} from "../lib/validation/activity";
+
+const VALID_UUID = "11111111-2222-3333-4444-555555555555";
+
+test("isUuid accepts canonical UUID and rejects garbage", () => {
+  assert.equal(isUuid(VALID_UUID), true);
+  assert.equal(isUuid("not-a-uuid"), false);
+  assert.equal(isUuid(""), false);
+  assert.equal(isUuid(123), false);
+});
+
+test("isSkillLevel/isFrequency/isTimeWindow/isLocationRadius/isCategory enforce enums", () => {
+  assert.equal(isSkillLevel("beginner"), true);
+  assert.equal(isSkillLevel("expert"), false);
+
+  assert.equal(isFrequency("weekly"), true);
+  assert.equal(isFrequency("yearly"), false);
+
+  assert.equal(isTimeWindow("weekday_morning"), true);
+  assert.equal(isTimeWindow("noon"), false);
+
+  assert.equal(isLocationRadius("walk"), true);
+  assert.equal(isLocationRadius("teleport"), false);
+
+  assert.equal(isCategory("sport"), true);
+  assert.equal(isCategory("ego"), false);
+});
+
+test("validateUserActivity — happy path", () => {
+  const r = validateUserActivity({
+    activityId: VALID_UUID,
+    skillLevel: "intermediate",
+    frequency: "weekly",
+    timeWindows: ["weekday_evening", "weekend_morning"],
+    locationRadius: "transit",
+    notes: "Looking for a hitting partner.",
+  });
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.deepEqual(r.value.timeWindows, ["weekday_evening", "weekend_morning"]);
+  assert.equal(r.value.notes, "Looking for a hitting partner.");
+});
+
+test("validateUserActivity — empty notes coerced to null", () => {
+  const r = validateUserActivity({
+    activityId: VALID_UUID,
+    skillLevel: "any",
+    frequency: "flexible",
+    timeWindows: ["weekday_morning"],
+    locationRadius: "walk",
+    notes: "   ",
+  });
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.value.notes, null);
+});
+
+test("validateUserActivity — rejects bad activityId", () => {
+  const r = validateUserActivity({
+    activityId: "nope",
+    skillLevel: "beginner",
+    frequency: "weekly",
+    timeWindows: ["weekday_evening"],
+    locationRadius: "walk",
+  });
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(r.errors.some((e) => e.field === "activityId"));
+});
+
+test("validateUserActivity — rejects empty timeWindows", () => {
+  const r = validateUserActivity({
+    activityId: VALID_UUID,
+    skillLevel: "beginner",
+    frequency: "weekly",
+    timeWindows: [],
+    locationRadius: "walk",
+  });
+  assert.equal(r.ok, false);
+});
+
+test("validateUserActivity — rejects unknown timeWindow value", () => {
+  const r = validateUserActivity({
+    activityId: VALID_UUID,
+    skillLevel: "beginner",
+    frequency: "weekly",
+    timeWindows: ["noon"],
+    locationRadius: "walk",
+  });
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(r.errors.some((e) => e.field === "timeWindows"));
+});
+
+test("validateUserActivity — rejects bad enums", () => {
+  const r = validateUserActivity({
+    activityId: VALID_UUID,
+    skillLevel: "guru",
+    frequency: "yearly",
+    timeWindows: ["weekday_morning"],
+    locationRadius: "teleport",
+  });
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  const fields = new Set(r.errors.map((e) => e.field));
+  assert.ok(fields.has("skillLevel"));
+  assert.ok(fields.has("frequency"));
+  assert.ok(fields.has("locationRadius"));
+});
+
+test("validateUserActivity — rejects oversize notes", () => {
+  const r = validateUserActivity({
+    activityId: VALID_UUID,
+    skillLevel: "beginner",
+    frequency: "weekly",
+    timeWindows: ["weekday_evening"],
+    locationRadius: "walk",
+    notes: "x".repeat(NOTES_MAX + 1),
+  });
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(r.errors.some((e) => e.field === "notes"));
+});
+
+test("validateUserActivity — dedupes timeWindows", () => {
+  const r = validateUserActivity({
+    activityId: VALID_UUID,
+    skillLevel: "beginner",
+    frequency: "weekly",
+    timeWindows: ["weekday_evening", "weekday_evening"],
+    locationRadius: "walk",
+  });
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.deepEqual(r.value.timeWindows, ["weekday_evening"]);
+});
+
+test("validateUserActivityPatch — empty body rejected", () => {
+  const r = validateUserActivityPatch({});
+  assert.equal(r.ok, false);
+});
+
+test("validateUserActivityPatch — single field accepted", () => {
+  const r = validateUserActivityPatch({ skillLevel: "advanced" });
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.value.skillLevel, "advanced");
+});
+
+test("validateUserActivityPatch — null notes clears the field", () => {
+  const r = validateUserActivityPatch({ notes: null });
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.value.notes, null);
+});
+
+test("validateActivityRequest — happy path", () => {
+  const r = validateActivityRequest({
+    slug: "frisbeeGolf",
+    displayName: "Frisbee Golf",
+    category: "outdoor",
+    justification: "Public-park sport, low equipment, easy to find a partner.",
+  });
+  assert.equal(r.ok, true);
+});
+
+test("validateActivityRequest — slug must be camelCase", () => {
+  const r = validateActivityRequest({
+    slug: "frisbee-golf",
+    displayName: "Frisbee Golf",
+    category: "outdoor",
+    justification: "ok",
+  });
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(r.errors.some((e) => e.field === "slug"));
+});
+
+test("validateActivityRequest — rejects oversize fields", () => {
+  const r = validateActivityRequest({
+    slug: "x".repeat(REQUEST_SLUG_MAX + 1),
+    displayName: "x".repeat(REQUEST_DISPLAY_NAME_MAX + 1),
+    category: "outdoor",
+    justification: "x".repeat(REQUEST_JUSTIFICATION_MAX + 1),
+  });
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  const fields = new Set(r.errors.map((e) => e.field));
+  assert.ok(fields.has("slug"));
+  assert.ok(fields.has("displayName"));
+  assert.ok(fields.has("justification"));
+});
+
+test("validateActivityRequest — rejects unknown category", () => {
+  const r = validateActivityRequest({
+    slug: "ok",
+    displayName: "ok",
+    category: "magic",
+    justification: "x",
+  });
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(r.errors.some((e) => e.field === "category"));
+});


### PR DESCRIPTION
## Summary

PR #111 (merged 2026-05-07) advertised Phase 2 backend work — 8 API routes, 79+ activity taxonomy seed, `requireHapUser()`, operator role per Constitution §V, validation utility, and `/api/health` activity-stats. The actual squash-merge of PR #111 contains **only the 7 locale JSON files**, identical to what PR #110 had merged minutes earlier. **Backend code never landed on main.**

This PR re-ships the missing work.

## Failure-mode diagnosis (PR #111)

- The squash-merge resolved against an empty backend delta because the backend commits were never actually present on the source ref `feat/hap-phase-2-backend` at squash time. The only commit on that branch was the locale work, which had already merged via PR #110.
- The PR body was written from a plan, not from the diff. Reviewer + auto-merge accepted on green CI without comparing the prose to the file list.
- A follow-up issue is filed (linked below) requesting **HiveOps v0.3 rule: post-merge verify PR claimed file additions** so descriptions and diffs are reconciled before merge. Until then, the convention is to anchor PR bodies to `git diff --stat` output, not to plan documents.

## What ships

**Schema (4 files, 010–013):**
- `010_hap_moderation_log.sql` — approve/reject decisions on user-requested taxonomy rows
- `011_seed_activity_taxonomy.sql` — 89 canonical activities (anchored to `locales/en.json` `activities` keys; user spec said 79 floor — exceeded)
- `012_hap_operator_audit.sql` — operator action log per Constitution §V
- `013_hap_operator_setup_code_state.sql` — single-use OPERATOR_SETUP_CODE consumption tracking

**Lib:**
- `lib/operator-auth.ts` — three markers (Clerk publicMetadata, HMAC-signed cookie, header), constant-time compare, 30-day TTL
- `lib/db-operator.ts` — `auditOperatorAction()` wrapper for write logging
- `lib/validation/activity.ts` — pure validators with explicit ValidationError shape
- `lib/auth.ts` — adds `requireHapUser()` (was a comment-only reference; now implemented with 401/403/404 status differentiation)

**API routes (8 files, 9 endpoints):**
- `GET /api/activities/list` — taxonomy with optional `?category=` filter, 1h s-maxage
- `POST /api/activities/request` — user-requested activity, rate-limited 1/7d/user
- `GET /api/activities/moderate` — operator-only, returns pending rows + requester city/age band + justification
- `POST /api/activities/moderate/[id]` — operator-only approve/reject with reason; logs both `hap_moderation_log` + `hap_operator_audit`
- `GET /api/users/me/activities` — own active rows, joined with taxonomy
- `POST /api/users/me/activities` — add or reactivate (idempotent on user_id+activity_id via the partial unique index)
- `PATCH /api/users/me/activities/[id]` — partial update of own row
- `DELETE /api/users/me/activities/[id]` — soft delete via is_active=false
- `POST /api/operator/login` — single-use OPERATOR_SETUP_CODE → signed `hap_operator` cookie

**Health extension:**
- `total_taxonomy_count`, `pending_moderation_count`, `total_user_activities`, `last_24h_user_activities`, `last_24h_taxonomy_requests`

**Defense in depth:** every user-data response runs through `stripForbidden()` or omits `exact_location_lat/lng` from the SELECT.

## Tests

- 23 unit tests covering all validators + operator-auth pure functions (HMAC sign/verify/expire/tamper, hash, constant-time compare).
- `npm test` runs `tsx --test test/*.test.ts` — no new heavy framework added.
- `tsc --noEmit` clean.
- HiveOps audit verdict locally: **PASS** (50 pass · 0 warn · 0 fail · 5 skip · 2 pre-existing waivers).

## Known gap (post-merge ops)

HAP Vercel project still needs the env vars provisioned for routes to work at runtime:
- `DATABASE_URL` (Neon)
- `CLERK_SK`, `CLERK_PK`
- `OPERATOR_AUTH_SECRET`, `OPERATOR_KEY`, `OPERATOR_SETUP_CODE` (per Constitution §V)
- 4 schema migrations (010–013) need to be applied — same migration pattern as 003/004 (run via `psql` against `DATABASE_URL` or via the engine's admin migrate route once one is added).

These were also pending after the original PR #111 per its body. A separate ops PR will wire up the env vars + migration runner.

## Test plan

- [ ] CI green (HiveOps audit, build)
- [ ] Auto-merge on green per standing merge rule
- [ ] Post-merge: `git pull` on local main; verify all files on disk
- [ ] Post-merge: smoke test endpoints return 401 (route exists) not 404 (route missing)
- [ ] Post-merge: re-run HiveOps audit on hive-activity-partner — must remain PASS

## Follow-up

Will file `saggarsonny-boop/hivebaby` issue: **HiveOps v0.3 candidate: post-merge verify PR claimed file additions** so the v0.3 rules can grep-check PR descriptions against actual diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
