### PR TITLE
fix(hive-activity-partner): add use client to strings.ts for Server Component compatibility

### DIFF
--- a/apps/hive-activity-partner/app/_lib/strings.ts
+++ b/apps/hive-activity-partner/app/_lib/strings.ts
@@ -1,3 +1,5 @@
+"use client";
+
 // Localized strings catalog for HiveActivityPartner.
 // English is the source of truth; all other locales must mirror its shape.
 // Canonical Hive free-tier locale set: en, es, fr, ar, hi, zh, pt.


### PR DESCRIPTION
## Summary
- \`app/_lib/strings.ts\` uses \`useEffect\`/\`useState\` at the top of the module but lacked the \`"use client"\` directive. Turbopack's import-trace pulled it into a Server Component branch via \`app/under-18/page.tsx\`, failing the build with \`You're importing a module that depends on useEffect into a React Server Component module\`.
- Adding \`"use client"\` marks the file as a Client Component. Server Components continue to consume strings via the standard Server→Client import boundary.

This was the second build error blocking HAP's first production deploy. The first (the @hive/onboarding workspace import) was fixed in PR #115.

## Test plan
- [ ] CI typecheck/audit green
- [ ] After merge, \`vercel deploy --prod\` from \`apps/hive-activity-partner/\`
- [ ] Smoke test \`/api/health\`, \`/api/activities/list\`, \`/api/operator/login\`, \`/profile/activities\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)