### PR TITLE
fix(parkback): React/JSX-runtime types error breaking preview deploys

### DIFF
--- a/apps/parkback/package-lock.json
+++ b/apps/parkback/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "parkback",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "next": "16.2.3",
         "react": "19.2.4",

--- a/apps/parkback/package.json
+++ b/apps/parkback/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "postinstall": "cd ../../packages/hive-onboarding && npm install --no-audit --no-fund --silent"
   },
   "dependencies": {
     "next": "16.2.3",

--- a/packages/hive-onboarding/package-lock.json
+++ b/packages/hive-onboarding/package-lock.json
@@ -1,0 +1,94 @@
+{
+  "name": "@hive/onboarding",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@hive/onboarding",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "react": "^19",
+        "react-dom": "^19",
+        "typescript": "^5"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/packages/hive-onboarding/package.json
+++ b/packages/hive-onboarding/package.json
@@ -25,6 +25,8 @@
   "devDependencies": {
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "react": "^19",
+    "react-dom": "^19",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary

The Vercel preview project `hivebaby-7c1o` (parkback's preview channel) has been failing on every PR since the `@hive/onboarding` package split. Surfaced by T3 in #103. This PR fixes it.

## Root cause

`apps/parkback/tsconfig.json` includes `../../packages/hive-onboarding/src/**/*.tsx` in its TypeScript program. With `moduleResolution: "bundler"`, TS walks UP from each file's location to find `node_modules`. From a file in `packages/hive-onboarding/src/`, the walk-up sequence is:

```
packages/hive-onboarding/node_modules/   ← didn't exist
packages/node_modules/                   ← doesn't exist
node_modules/ (repo root)                ← doesn't exist
```

No `node_modules` anywhere on that walk-up path. tsc can't find `react/jsx-runtime` types and fails at every JSX tag in the package — `HiveAHTSPrompt.tsx:47` was the first one alphabetically, which is why the error always pointed there.

`apps/parkback/node_modules/` has `react` + `@types/react` installed (28 packages, types ship in `node_modules/@types/react/jsx-runtime.d.ts`), but the walk-up from `packages/hive-onboarding/src/` doesn't traverse `apps/parkback/`.

## Approaches considered (and rejected)

- **`paths` alias for `react`** — paths bypass the `@types/<pkg>` adjacency lookup, so `react` resolves to JS but not types. Tried it; got `Could not find a declaration file for module 'react'`.
- **Remove `packages/hive-onboarding/**/*` from parkback's tsconfig `include`** — Next.js's TS checker follows the import graph regardless of `include`, so the package files still got pulled in for type-check. Same error.
- **Convert repo to npm workspaces** — would change install behavior for every other engine in the monorepo. Too invasive.
- **`paths` with wildcard `"*": ["node_modules/*"]`** — would apply to every module name, including ones that should resolve from elsewhere. Brittle.
- **TypeScript project references with `composite: true`** — significant config change across the package; not warranted for a build fix.

## Fix

Three small changes:

1. **`packages/hive-onboarding/package.json`** — add `react@^19` and `react-dom@^19` to `devDependencies` (alongside `@types/react@^19` which was already there). Now `npm install` inside the package creates a `node_modules/` with the runtime + types that tsc's walk-up will find.

2. **`apps/parkback/package.json`** — add a `postinstall` script: `cd ../../packages/hive-onboarding && npm install --no-audit --no-fund --silent`. Vercel's CI installs only in `apps/parkback` by default; the postinstall covers the package without needing a workspaces config (which would change the install pattern for every other engine).

3. **`packages/hive-onboarding/package-lock.json`** — added so the install is deterministic.

## What this does NOT change

- The `peerDependencies` on `react`/`react-dom` in hive-onboarding stay — they still signal to consumers that they must provide a compatible react. The new `devDependencies` entries are only for the package's own typecheck/dev; consumer contracts don't change.
- No tsconfig changes, no engine code changes, no resolution-magic.
- HAP (hive-activity-partner) has the same `tsconfig include` pattern — once T1's deploy-unblock PR lands HAP-side, HAP can adopt the same postinstall pattern (or T1's inline approach removes the dependency entirely). **This PR is scoped to parkback only.**

## Verification (clean simulation)

```sh
rm -rf packages/hive-onboarding/node_modules apps/parkback/node_modules
cd apps/parkback && npm install --no-audit --no-fund
# → postinstall fires, hive-onboarding gets node_modules with react + @types/react
npm run build
# → ✓ Compiled successfully
# → Running TypeScript ... (passes)
# → static + dynamic routes generated
```

The original error
```
../../packages/hive-onboarding/src/HiveAHTSPrompt.tsx:47:5
Type error: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found.
```
no longer reproduces.

## Test plan

- [ ] CI green
- [ ] `Vercel – hivebaby-7c1o` check turns from `fail` to `pass` on this PR
- [ ] Auto-merge on green CI per standing rule
- [ ] Verify hivebaby-7c1o stays green on subsequent PRs

## Coordination

Branch lives in a separate worktree (`/Users/sonnyneo/hivebaby-t2-fix`) to avoid stomping on T1's `fix/hap-dedicated-db-and-inline-onboarding` and T3's `feat/hap-phase-2-safety-layer` work in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
