### PR TITLE
fix(hive-activity-partner): split strings.ts (server-safe data) from useStrings.ts (client hook)

### DIFF
--- a/apps/hive-activity-partner/app/_lib/HiveFirstVisitExplainer.tsx
+++ b/apps/hive-activity-partner/app/_lib/HiveFirstVisitExplainer.tsx
@@ -5,7 +5,7 @@
 // so the home page imports a single component with no per-engine config.
 
 import { HiveFirstVisitExplainer as PackageHiveFirstVisitExplainer } from "@/lib/hive-onboarding";
-import { useStrings } from "./strings";
+import { useStrings } from "./useStrings";
 
 export function HiveFirstVisitExplainer() {
   const s = useStrings();

--- a/apps/hive-activity-partner/app/_lib/HiveFooter.tsx
+++ b/apps/hive-activity-partner/app/_lib/HiveFooter.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import { useStrings } from "./strings";
+import { useStrings } from "./useStrings";
 
 const GOLD = "#D4AF37";
 const GOLD_DIM = "#8a6f1f";

--- a/apps/hive-activity-partner/app/_lib/HiveInstallHint.tsx
+++ b/apps/hive-activity-partner/app/_lib/HiveInstallHint.tsx
@@ -6,7 +6,7 @@
 // import.
 
 import { HiveInstallHint as PackageHiveInstallHint } from "@/lib/hive-onboarding";
-import { useStrings } from "./strings";
+import { useStrings } from "./useStrings";
 
 export function HiveInstallHint() {
   const s = useStrings();

--- a/apps/hive-activity-partner/app/_lib/strings.ts
+++ b/apps/hive-activity-partner/app/_lib/strings.ts
@@ -4,7 +4,8 @@
 //
 // This module is server-safe (no React hooks). Server Components import
 // `strings` directly. Client Components that need locale switching import
-// `useStrings` from "./useStrings" — that file owns the "use client" boundary.
+// `useStrings` from "./useStrings" — that file owns the "use client" boundary
+// and reads `navigator.language` to pick the active catalog at runtime.
 
 import en from "../../locales/en.json";
 import es from "../../locales/es.json";

--- a/apps/hive-activity-partner/app/_lib/strings.ts
+++ b/apps/hive-activity-partner/app/_lib/strings.ts
@@ -1,10 +1,11 @@
-"use client";
-
 // Localized strings catalog for HiveActivityPartner.
 // English is the source of truth; all other locales must mirror its shape.
 // Canonical Hive free-tier locale set: en, es, fr, ar, hi, zh, pt.
+//
+// This module is server-safe (no React hooks). Server Components import
+// `strings` directly. Client Components that need locale switching import
+// `useStrings` from "./useStrings" — that file owns the "use client" boundary.
 
-import { useEffect, useState } from "react";
 import en from "../../locales/en.json";
 import es from "../../locales/es.json";
 import fr from "../../locales/fr.json";
@@ -15,23 +16,13 @@ import pt from "../../locales/pt.json";
 
 export type Strings = typeof en;
 
-const CATALOGS: Record<string, Strings> = { en, es, fr, ar, hi, zh, pt };
+export const CATALOGS: Record<string, Strings> = { en, es, fr, ar, hi, zh, pt };
 
 export const strings: Strings = en;
 
-function pickLocale(navigatorLanguage: string | undefined): keyof typeof CATALOGS {
+export function pickLocale(navigatorLanguage: string | undefined): keyof typeof CATALOGS {
   if (!navigatorLanguage) return "en";
   const primary = navigatorLanguage.toLowerCase().split("-")[0];
   if (primary in CATALOGS) return primary as keyof typeof CATALOGS;
   return "en";
-}
-
-export function useStrings(): Strings {
-  const [s, setS] = useState<Strings>(en);
-  useEffect(() => {
-    if (typeof navigator === "undefined") return;
-    const code = pickLocale(navigator.language);
-    setS(CATALOGS[code]);
-  }, []);
-  return s;
 }

--- a/apps/hive-activity-partner/app/_lib/useStrings.ts
+++ b/apps/hive-activity-partner/app/_lib/useStrings.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CATALOGS, pickLocale, strings, type Strings } from "./strings";
+
+export function useStrings(): Strings {
+  const [s, setS] = useState<Strings>(strings);
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+    const code = pickLocale(navigator.language);
+    setS(CATALOGS[code]);
+  }, []);
+  return s;
+}

--- a/apps/hive-activity-partner/app/signup/page.tsx
+++ b/apps/hive-activity-partner/app/signup/page.tsx
@@ -13,7 +13,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { AGE_BANDS, type AgeBand } from "@/lib/profile";
-import { useStrings } from "../_lib/strings";
+import { useStrings } from "../_lib/useStrings";
 
 const GOLD = "#D4AF37";
 const PAPER = "#f5f1e6";


### PR DESCRIPTION
## Summary
PR #118's \`"use client"\` on \`strings.ts\` flipped the whole module to a Client Component boundary. Server Components that imported the \`strings\` data constant (\`app/under-18/page.tsx\`, \`app/page.tsx\`) then got a client reference instead of the actual \`en\` JSON object — prerender failed with \`TypeError: Cannot read properties of undefined (reading 'title')\`.

Split the module:
- \`app/_lib/strings.ts\` — server-safe: locale JSON imports, \`Strings\` type, \`strings\` constant, \`CATALOGS\`, \`pickLocale\`. No directive, no hooks.
- \`app/_lib/useStrings.ts\` (new) — \`"use client"\`, imports data from \`./strings\`, exports the \`useStrings\` hook.

Consumers updated: \`HiveInstallHint\`, \`HiveFirstVisitExplainer\`, \`HiveFooter\`, \`signup/page.tsx\` now import \`useStrings\` from \`./useStrings\`. \`under-18/page.tsx\` and root \`page.tsx\` keep importing \`strings\` from \`./strings\` unchanged.

Reverts the \`"use client"\` directive added to \`strings.ts\` in PR #118.

## Test plan
- [ ] CI audit green
- [ ] After merge, \`vercel deploy --prod\` from \`apps/hive-activity-partner/\`
- [ ] Smoke: \`/api/health\`, \`/api/activities/list\` (89 entries), \`/api/operator/login\`, \`/profile/activities\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)