### PR TITLE
fix(hive-activity-partner): add operator-login and activities/list to middleware isPublic

### DIFF
--- a/apps/hive-activity-partner/middleware.ts
+++ b/apps/hive-activity-partner/middleware.ts
@@ -12,6 +12,8 @@ const isPublic = createRouteMatcher([
   "/sign-in(.*)",
   "/sign-up(.*)",
   "/api/health",
+  "/api/activities/list",
+  "/api/operator/login",
   "/_next/(.*)",
   "/favicon.ico",
   "/robots.txt",


### PR DESCRIPTION
## Summary
Two routes were being rewritten to /404 by \`clerkMiddleware\` because they weren't in the \`isPublic\` matcher:

- \`/api/operator/login\` — the bootstrap-before-Clerk flow (exchange a single-use \`OPERATOR_SETUP_CODE\` for the signed \`hap_operator\` cookie). Auth-gating it makes the operator login impossible to reach without already being authed.
- \`/api/activities/list\` — read-only taxonomy data; needs to render the 89 seeded activities for unauth visitors.

Both surfaced during the post-migration smoke test as 404s with \`x-clerk-auth-reason: protect-rewrite\`. The routes themselves are fine.

## Test plan
- [ ] CI audit green
- [ ] After merge + redeploy: \`POST /api/operator/login\` returns the operator cookie (or a route-level error, not Clerk's 404 rewrite)
- [ ] \`GET /api/activities/list\` returns the 89 taxonomy entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)