### PR TITLE
ops(hive-activity-partner): wire DNS + Git connection + verify operator login

### DIFF
--- a/registry/dns-inventory.md
+++ b/registry/dns-inventory.md
@@ -5,3 +5,4 @@ Subdomains under `hive.baby` (Cloudflare zone `bcb5522993ecf90a4f1d5dfe101e5a5c`
 | Subdomain | Target | Type | Registered date | Notes |
 |---|---|---|---|---|
 | parkback.hive.baby | cname.vercel-dns.com | CNAME | 2026-05-04 | Live. Vercel project: `hivebaby-7c1o` (root: `apps/parkback`). |
+| activitypartner.hive.baby | cname.vercel-dns.com | CNAME | 2026-05-08 | Live. Vercel project: `hive-activity-partner` (root: `apps/hive-activity-partner`). Git connection wired to `saggarsonny-boop/hivebaby` main. |


### PR DESCRIPTION
## Summary
- Created Cloudflare CNAME `activitypartner.hive.baby` → `cname.vercel-dns.com` (record id `fc608cda77dd43b122a1e4d7db1170a0`).
- Attached the domain to the HAP Vercel project (`prj_VbIU32ZKPNcODHjTqtECUyqGOGMh`); already returns HTTP 200.
- Connected the HAP Vercel project to GitHub `saggarsonny-boop/hivebaby` (production branch `main`, `rootDirectory = apps/hive-activity-partner`) so push-to-main now auto-deploys HAP.
- Rotated `OPERATOR_SETUP_CODE` (sensitive env var). End-to-end smoke test of `POST /api/operator/login` runs after the auto-deploy that this merge triggers; result is reported back in chat.

Only documentation diff in this PR (`registry/dns-inventory.md`); the infra changes are out-of-band Cloudflare + Vercel API calls.

## Test plan
- [ ] CI green
- [ ] Auto-merge + auto-deploy of HAP from `main`
- [ ] `curl -sI https://activitypartner.hive.baby` → 200
- [ ] `POST /api/operator/login` with the rotated code returns 200 + `Set-Cookie: hap_operator=...`
- [ ] Final `OPERATOR_SETUP_CODE` rotation lands on next HAP deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)