### PR TITLE
fix(hive-activity-partner): repair non-functional Get Started button on home page

### DIFF
--- a/apps/hive-activity-partner/app/profile/activities/MyActivitiesList.tsx
+++ b/apps/hive-activity-partner/app/profile/activities/MyActivitiesList.tsx
@@ -10,7 +10,8 @@
 
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
-import { useStrings, type Strings } from "../../_lib/strings";
+import { type Strings } from "../../_lib/strings";
+import { useStrings } from "../../_lib/useStrings";
 import {
   CARD,
   CHIP,

--- a/apps/hive-activity-partner/app/profile/activities/[id]/edit/EditActivityForm.tsx
+++ b/apps/hive-activity-partner/app/profile/activities/[id]/edit/EditActivityForm.tsx
@@ -10,7 +10,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useStrings, type Strings } from "../../../../_lib/strings";
+import { type Strings } from "../../../../_lib/strings";
+import { useStrings } from "../../../../_lib/useStrings";
 import {
   CARD,
   ERROR_BOX,

--- a/apps/hive-activity-partner/app/profile/activities/new/AddActivityFlow.tsx
+++ b/apps/hive-activity-partner/app/profile/activities/new/AddActivityFlow.tsx
@@ -20,7 +20,8 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useStrings, type Strings } from "../../../_lib/strings";
+import { type Strings } from "../../../_lib/strings";
+import { useStrings } from "../../../_lib/useStrings";
 import {
   CARD,
   ERROR_BOX,


### PR DESCRIPTION
## Summary
- Three activity-flow components (`MyActivitiesList`, `EditActivityForm`, `AddActivityFlow`) still imported `useStrings` from `_lib/strings` after PR #122 split the client hook into `_lib/useStrings`.
- The static export failed with `Export useStrings doesn't exist in target module`. Build failures cascaded; the home page's `<Link href="/signup">` lost its prefetch chunk and clicking "Get Started" silently no-op'd.
- Each affected file now imports `type Strings` from `_lib/strings` (server-safe) and `useStrings` from `_lib/useStrings` (client hook), mirroring the convention in `app/signup/page.tsx`.
- This PR also unblocks the HAP build (was failing on the `ops/hap-dns-git-operator-verify` PR for the same reason).

## Root cause
PR #122 moved the `useStrings` hook out of `_lib/strings` into `_lib/useStrings` so server components could import the catalog without dragging the `"use client"` boundary in. Three callers under `app/profile/activities/` were not updated in the split.

## Test plan
- [ ] CI green
- [ ] Auto-merge + auto-deploy lands a fresh production build
- [ ] `curl -sI https://activitypartner.hive.baby/signup` → 200
- [ ] Manual: from `/`, click "Get Started" — navigates to `/signup` age-band gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)