### PR TITLE
fix(hive-activity-partner): repair non-functional Get Started button on home page

### DIFF
--- a/apps/hive-activity-partner/app/page.tsx
+++ b/apps/hive-activity-partner/app/page.tsx
@@ -1,7 +1,11 @@
 // Landing page. Plain English, mobile-first, no marketing fluff.
 // CTA routes to /signup which captures the age band BEFORE Clerk.
+//
+// Plain <a> rather than next/link: under Next 16.2.3 + React 19 + Clerk 6 +
+// Turbopack, the Link onClick handler preventDefaults the click but never
+// triggers router.push (verified with Playwright on prod). Native <a>
+// navigation reliably reaches /signup.
 
-import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { strings } from "./_lib/strings";
@@ -42,12 +46,12 @@ export default async function Home() {
         </div>
       </div>
 
-      <Link href="/signup" style={ctaStyle} aria-label={s.ctaAria}>
+      <a href="/signup" style={ctaStyle} aria-label={s.ctaAria}>
         {s.cta}
-      </Link>
-      <Link href="/sign-in" style={signInLinkStyle}>
+      </a>
+      <a href="/sign-in" style={signInLinkStyle}>
         {s.signInPrompt}
-      </Link>
+      </a>
 
       <HiveInstallHint />
       <HiveFirstVisitExplainer />


### PR DESCRIPTION
## Summary
- Home page Get Started CTA no longer navigates on left-click.
- Root cause (verified with Playwright on prod): under Next 16.2.3 + React 19.2.4 + Clerk 6 + Turbopack, the `next/link` onClick handler `preventDefault`s the click but never triggers `router.push`. Plain `<a>` navigation works fine; `/signup` returns 200; only Link's intercept is broken.
- Fix: drop `next/link` for the two home-page CTAs (Get Started, Sign in) and use plain `<a>`. Loses client-side soft navigation for the landing → signup transition only; everything past /signup keeps using next/link.

## Diagnosis evidence
| Probe | Result |
|---|---|
| HTML rendered correctly with `<a href="/signup">` | ✓ |
| React fiber on the Link has `onClick: function` | ✓ |
| Click sets `event.defaultPrevented = true` | ✓ |
| Any `history.pushState` / `replaceState` / `popstate` after click | ✗ (none) |
| Plain `<a href="/signup">` injected & clicked next to the broken Link | navigates immediately |
| `/signup` returns 200 with the age-band gate body | ✓ |
| Console errors / page errors | none (Clerk dev-key warning only) |

The user reported "right-click opens the age-band confirmation modal" — Playwright did not reproduce that (no modal mounted, no `[role=dialog]` in DOM). The age-band gate is a separate `/signup` page in the current Phase 1 design, not a modal. This PR makes the left-click navigation reliable; if a modal redesign is wanted, it's a separate scope.

## Test plan
- [ ] CI green
- [ ] Auto-deploy
- [ ] Playwright re-probe: left-click on Get Started → URL changes to `/signup` and age-band gate renders
- [ ] Sign in link similarly navigates on left-click

🤖 Generated with [Claude Code](https://claude.com/claude-code)