### PR TITLE
feat(hive-ops): cross-repo audit + per-PR audit guardrail to prevent silent regressions

### DIFF
--- a/.github/workflows/hive-ops-daily-sweep.yml
+++ b/.github/workflows/hive-ops-daily-sweep.yml
@@ -1,6 +1,10 @@
-name: HiveOps — daily warn-mode sweep
+name: HiveOps — daily warn-mode sweep + cross-repo audit
 
-# Daily auto-flip of expired warn-mode overrides to enforce.
+# Daily auto-flip of expired warn-mode overrides to enforce, plus a
+# cross-repo audit pass that exercises external Hive engine repos
+# (UD Converter, HiveEngineBuilder, HiveAdminSupport, …) so verdict
+# regressions are detected daily — not weeks after the fact when
+# someone runs an audit by hand.
 #
 # What it does:
 #   1. Scans every apps/<engine>/ENGINE_GRAMMAR.md for ## Hive-Ops
@@ -9,22 +13,32 @@ name: HiveOps — daily warn-mode sweep
 #      default enforce — exactly the behavior the runner's
 #      applyOverride() in runner.ts already triggers when warn_until
 #      lapses; the sweep just makes the file reflect that state).
-#   3. Writes one row per flip + one per imminent expiry + one summary
-#      to the hive_alerts table.
-#   4. Commits any manifest mutations directly to main (the sweep IS
+#   3. Runs cross-repo audit (tools/hive-ops/crossRepoAudit.ts) over
+#      every engine listed in tools/hive-ops/external-engines.json,
+#      cloning each repo fresh, running the SAME runHiveOps() the in-
+#      tree sweep uses, and aggregating verdicts into the daily report.
+#      tier-2 hive_alerts inserted on FAIL.
+#   4. Writes one hive_alerts row per flip + one per imminent expiry +
+#      one summary row + one per cross-repo FAIL.
+#   5. Commits any manifest mutations directly to main (the sweep IS
 #      the authoritative actor; a PR per day would be noise) and opens
 #      or updates today's "HiveOps Daily Sweep Report YYYY-MM-DD"
-#      issue with the full audit trail.
+#      issue with the full audit trail (in-tree + cross-repo sections).
 #
 # Permissions:
 #   contents: write       — to commit ENGINE_GRAMMAR.md mutations
 #   issues:   write       — to open / update the daily status issue
 #   pull-requests: write  — reserved; not used today (commits go direct)
 #
-# Secrets:
+# Secrets / tokens:
 #   DATABASE_URL          — Postgres connection string for hive_alerts
 #                           (already in repo secrets per ci-doctor + the
 #                           query-hive-alerts.yml workflow)
+#   GITHUB_TOKEN          — default token; used by crossRepoAudit.ts to
+#                           clone external Hive engine repos. The default
+#                           token only has read access to the org's public
+#                           repos, which is exactly what we need (no
+#                           write back to external repos from the sweep).
 
 on:
   schedule:
@@ -65,6 +79,10 @@ jobs:
         working-directory: tools/hive-ops
         run: npm ci --no-audit --no-fund || npm install --no-audit --no-fund
 
+      - name: Install hive-finalize deps (cross-repo audit needs V-rules)
+        working-directory: tools/hive-finalize
+        run: npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+
       - name: Install psql (for hive_alerts inserts)
         run: |
           sudo apt-get update -qq
@@ -96,6 +114,55 @@ jobs:
             cat /tmp/sweep-output.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run cross-repo audit (external engines)
+        id: cross
+        env:
+          # GITHUB_TOKEN gives the cloner read access to
+          # saggarsonny-boop's public repos. DATABASE_URL is required
+          # for tier-2 FAIL alerts.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -uo pipefail
+          FLAGS=""
+          if [ "${DRY_RUN:-false}" = "true" ]; then FLAGS="--dry-run"; fi
+          # crossRepoAudit.ts always exits 0 (verdicts in the report,
+          # not the exit code) unless tooling itself errors. Failing
+          # external engines surface via tier-2 hive_alerts + the
+          # external-engines section of the daily issue.
+          npx --prefix tools/hive-ops tsx tools/hive-ops/crossRepoAudit.ts \
+            --out /tmp/hive-ops-cross-repo.md $FLAGS \
+            | tee /tmp/cross-repo-output.txt
+          echo "ran=true" >> "$GITHUB_OUTPUT"
+
+      - name: Append cross-repo summary to step summary + issue body
+        if: always() && steps.cross.outputs.ran == 'true'
+        run: |
+          {
+            echo ""
+            echo "## Cross-repo audit"
+            echo ""
+            echo '```'
+            cat /tmp/cross-repo-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Concatenate the cross-repo Markdown section onto the daily
+          # issue body produced by dailySweep.ts. The downstream "Open
+          # or update daily report issue" step picks up the merged file.
+          if [ -f /tmp/hive-ops-sweep-issue.md ] && [ -f /tmp/hive-ops-cross-repo.md ]; then
+            cat /tmp/hive-ops-cross-repo.md >> /tmp/hive-ops-sweep-issue.md
+          elif [ -f /tmp/hive-ops-cross-repo.md ]; then
+            # No in-tree changes today, so dailySweep didn't write the
+            # issue body. Synthesize a minimal header so the cross-repo
+            # section still publishes.
+            {
+              printf '# HiveOps Daily Sweep — %s\n\n' "$(date -u +%Y-%m-%d)"
+              printf '_No in-tree warn-mode flips today; cross-repo audit ran._\n'
+              cat /tmp/hive-ops-cross-repo.md
+            } > /tmp/hive-ops-sweep-issue.md
+          fi
 
       - name: Commit manifest mutations (if any)
         id: commit

--- a/.github/workflows/hive-ops-pr-audit-reusable.yml
+++ b/.github/workflows/hive-ops-pr-audit-reusable.yml
@@ -1,0 +1,225 @@
+name: HiveOps PR audit (reusable)
+
+# Reusable workflow that any external Hive engine repo can call from
+# its own .github/workflows/hive-ops-pr-audit.yml on pull_request to
+# main. Checks out hivebaby for the hive-ops + hive-finalize tooling,
+# then runs `tsx tools/hive-ops/cli.ts <slug> --repo <caller-checkout>`.
+#
+# The caller workflow is the canonical "subscribe my engine to HiveOps"
+# pattern — see HIVE_CONSTITUTION.md §V "Per-PR audit guardrail".
+#
+# Caller form (commit at .github/workflows/hive-ops-pr-audit.yml in
+# the engine repo):
+#
+#   name: HiveOps PR audit
+#   on:
+#     pull_request:
+#       branches: [main]
+#   jobs:
+#     audit:
+#       uses: saggarsonny-boop/hivebaby/.github/workflows/hive-ops-pr-audit-reusable.yml@main
+#       with:
+#         slug: <engine-slug>          # e.g. "converter" for monorepo, or
+#                                      #      the standalone repo's name
+#       permissions:
+#         pull-requests: write         # so the audit comment can be posted
+#         contents: read
+#
+# Behaviour:
+#   - PASS  → CI green, no PR comment.
+#   - WARN  → CI green, PR comment with the warn-rule list and warn_until.
+#   - FAIL  → CI red, PR comment with failing rules and what to fix.
+#   - tooling error → CI red, exits 2 (so the caller knows the audit
+#     itself didn't run, not that the engine failed compliance).
+#
+# Verdict-degradation guard: if the engine's main-branch verdict is
+# PASS but this PR's verdict is WARN/FAIL, the comment escalates to
+# bold "VERDICT REGRESSION" wording. The check still passes/fails on
+# the absolute verdict, not the delta — preventing a "was already FAIL"
+# pre-existing state from blocking unrelated PRs.
+
+on:
+  workflow_call:
+    inputs:
+      slug:
+        description: "Engine slug — directory name under apps/<slug> for monorepos, or the engine's own name for standalone repos. Must match the slug HiveOps uses to resolve the manifest."
+        required: true
+        type: string
+      hivebaby_ref:
+        description: "Ref of saggarsonny-boop/hivebaby to pull tooling from. Defaults to main."
+        required: false
+        type: string
+        default: main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout caller (the engine repo PR branch)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: engine
+
+      - name: Checkout hivebaby (for hive-ops + hive-finalize tooling)
+        uses: actions/checkout@v4
+        with:
+          repository: saggarsonny-boop/hivebaby
+          ref: ${{ inputs.hivebaby_ref }}
+          path: hivebaby
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install hive-ops deps
+        working-directory: hivebaby/tools/hive-ops
+        run: npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+
+      - name: Install hive-finalize deps
+        working-directory: hivebaby/tools/hive-finalize
+        run: npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+
+      - name: Resolve engine main-branch verdict (for regression detection)
+        id: baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Best-effort: clone main of the caller repo into a sibling
+          # directory and run the audit there. If anything fails, we
+          # treat the baseline as "unknown" — the PR audit still runs
+          # and reports its own absolute verdict.
+          BASE_SLUG="${{ inputs.slug }}"
+          BASELINE_DIR="${RUNNER_TEMP}/baseline"
+          rm -rf "$BASELINE_DIR"
+          git clone --depth 1 --branch main "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$BASELINE_DIR" || {
+            echo "baseline=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          BASE_VERDICT=$(npx --prefix hivebaby/tools/hive-ops tsx hivebaby/tools/hive-ops/cli.ts "$BASE_SLUG" --repo "$BASELINE_DIR" --json 2>/dev/null | jq -r '.verdict // empty' || echo "")
+          if [ -z "${BASE_VERDICT}" ]; then BASE_VERDICT=unknown; fi
+          echo "baseline=$BASE_VERDICT" >> "$GITHUB_OUTPUT"
+          echo "Baseline verdict on main: $BASE_VERDICT"
+
+      - name: Run HiveOps audit on PR branch
+        id: audit
+        run: |
+          set -uo pipefail
+          npx --prefix hivebaby/tools/hive-ops tsx hivebaby/tools/hive-ops/cli.ts "${{ inputs.slug }}" --repo "$GITHUB_WORKSPACE/engine" --json > /tmp/hive-ops-report.json
+          AUDIT_EXIT=$?
+          if [ $AUDIT_EXIT -eq 2 ]; then
+            echo "verdict=tooling-error" >> "$GITHUB_OUTPUT"
+            echo "::error title=HiveOps tooling error::audit exited 2 — see logs"
+            exit 2
+          fi
+          VERDICT=$(jq -r '.verdict' /tmp/hive-ops-report.json)
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+          echo "PR-branch verdict: $VERDICT"
+          # also produce human-readable for the comment + step summary
+          npx --prefix hivebaby/tools/hive-ops tsx hivebaby/tools/hive-ops/cli.ts "${{ inputs.slug }}" --repo "$GITHUB_WORKSPACE/engine" > /tmp/hive-ops-report.txt 2>&1 || true
+          {
+            echo "## HiveOps PR audit — \`${{ inputs.slug }}\`"
+            echo ""
+            echo "Baseline (main): \`${{ steps.baseline.outputs.baseline }}\`"
+            echo "PR verdict:      \`$VERDICT\`"
+            echo ""
+            echo '```'
+            cat /tmp/hive-ops-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build PR comment body
+        if: github.event_name == 'pull_request'
+        id: comment
+        env:
+          BASELINE: ${{ steps.baseline.outputs.baseline }}
+          VERDICT: ${{ steps.audit.outputs.verdict }}
+          SLUG: ${{ inputs.slug }}
+        run: |
+          set -euo pipefail
+          REGRESSION="false"
+          if [ "$BASELINE" = "pass" ] && [ "$VERDICT" != "pass" ]; then REGRESSION="true"; fi
+          {
+            if [ "$REGRESSION" = "true" ]; then
+              echo "## ⚠️ HiveOps verdict regression on \`${SLUG}\`"
+              echo ""
+              echo "**Baseline (main): \`${BASELINE}\` → PR branch: \`${VERDICT}\`.**"
+              echo ""
+              echo "This PR moves the engine off PASS. Either fix the failing/warning rules or add a documented \`mode: warn\` override per the schema in [HIVE_CONSTITUTION.md §V](https://github.com/saggarsonny-boop/hivebaby/blob/main/docs/HIVE_CONSTITUTION.md#v-hiveops-governance) before merge."
+            elif [ "$VERDICT" = "fail" ]; then
+              echo "## ❌ HiveOps verdict: FAIL"
+              echo ""
+              echo "Engine \`${SLUG}\` is FAILing on this PR (and was already FAIL on main — not introduced here, but flagged for visibility)."
+            elif [ "$VERDICT" = "warn" ]; then
+              echo "## ⚠️ HiveOps verdict: WARN"
+              echo ""
+              echo "Engine \`${SLUG}\` audits as WARN on this PR. Each warn entry expires on a date documented in the engine's \`ENGINE_GRAMMAR.md\` overrides block; check the audit detail below."
+            else
+              # PASS — only post a comment if regression flag would have flipped (it didn't)
+              echo ""
+            fi
+            if [ "$VERDICT" != "pass" ] || [ "$REGRESSION" = "true" ]; then
+              echo ""
+              echo "<details><summary>HiveOps audit detail</summary>"
+              echo ""
+              echo '```'
+              cat /tmp/hive-ops-report.txt
+              echo '```'
+              echo ""
+              echo "</details>"
+            fi
+          } > /tmp/hive-ops-comment.md
+          # only set output if we have meaningful content
+          if [ -s /tmp/hive-ops-comment.md ] && [ "$VERDICT" != "pass" -o "$REGRESSION" = "true" ]; then
+            echo "post=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "post=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post / update PR comment
+        if: github.event_name == 'pull_request' && steps.comment.outputs.post == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- hive-ops-pr-audit-${{ inputs.slug }} -->"
+          BODY=$(cat /tmp/hive-ops-comment.md)
+          BODY="${MARKER}"$'\n'"${BODY}"
+          # Look for an existing comment with our marker; update in
+          # place if found, otherwise create.
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -n 1)
+          if [ -n "${EXISTING:-}" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" \
+              -f body="${BODY}" >/dev/null
+            echo "Updated existing PR comment ${EXISTING}"
+          else
+            gh api -X POST "repos/${REPO}/issues/${PR}/comments" \
+              -f body="${BODY}" >/dev/null
+            echo "Posted new PR comment"
+          fi
+
+      - name: Fail the check if verdict is fail
+        if: always()
+        env:
+          VERDICT: ${{ steps.audit.outputs.verdict }}
+        run: |
+          if [ "$VERDICT" = "fail" ]; then
+            echo "::error title=HiveOps verdict=fail::engine ${{ inputs.slug }} failed audit on this PR — see PR comment for failing rules"
+            exit 1
+          fi
+          if [ "$VERDICT" = "tooling-error" ]; then
+            exit 2
+          fi
+          # pass / warn → check passes
+          echo "HiveOps verdict: $VERDICT — check passes"

--- a/docs/HIVE_CONSTITUTION.md
+++ b/docs/HIVE_CONSTITUTION.md
@@ -536,6 +536,65 @@ Required env vars per engine: `OPERATOR_AUTH_SECRET` (32-byte base64; HMAC signi
 
 Reference implementation: `apps/converter/src/lib/operator-auth.ts` in `saggarsonny-boop/universal-document` (PR #22). HiveOps v0.3 will add a rule (likely **H29**) verifying any tier-gated engine imports this pattern; until then, the convention is documented here and engines self-attest in their `ENGINE_GRAMMAR.md`.
 
+### Cross-repo audit — daily sweep covers external engines  `[CROSS_REPO_AUDIT]`
+
+The daily sweep (`.github/workflows/hive-ops-daily-sweep.yml`) used to scan only `apps/<engine>/ENGINE_GRAMMAR.md` inside the hivebaby monorepo. External-repo engines — UD Converter, HiveEngineBuilder, HiveAdminSupport, UniversalDocumentInc, etc. — were invisible to it; verdict drift went undetected for days at a time. PR #131 (the T4 audit doc) surfaced this gap, and the next PR built the fix.
+
+The sweep now ALSO clones every engine listed in `tools/hive-ops/external-engines.json`, runs the same `runHiveOps()` against each clone, and merges the results into the daily issue body under an `## External-repo engines` section. Tier-2 `hive_alerts` are inserted on every external FAIL (action_url points at the engine repo so the alert is actionable). The orchestrator is `tools/hive-ops/crossRepoAudit.ts`; it uses `GITHUB_TOKEN` to clone (read-only, public repos only) and is best-effort — clone failures or missing manifests show up as `🚧 ERROR` rows, never crash the sweep.
+
+To register a new external engine:
+
+```jsonc
+// tools/hive-ops/external-engines.json
+{
+  "engines": [
+    {
+      "slug": "converter",                              // dir name HiveOps uses
+      "engine_name": "UDConverter",                     // display label
+      "repo": "saggarsonny-boop/universal-document",    // owner/name
+      "default_branch": "main",
+      "subdir_pattern": "monorepo",                     // "monorepo" if at apps/<slug>; "root" if standalone
+      "domain": "converter.hive.baby"
+    }
+  ]
+}
+```
+
+The runner's `resolveEngineRoot()` checks three locations in order: `<repoRoot>/apps/<slug>`, `<repoRoot>/<slug>`, `<repoRoot>` itself (when an `ENGINE_GRAMMAR.md` lives at the repo root). External-repo engines work in either monorepo or standalone form without code changes.
+
+### Per-PR audit guardrail — every engine repo, every PR  `[PR_GUARDRAIL]`
+
+In-tree engines (anything under `hivebaby/apps/`) are PR-audited by `.github/workflows/hive-ops.yml`. External-repo engines have a corresponding reusable workflow: `.github/workflows/hive-ops-pr-audit-reusable.yml`. Each engine repo subscribes by committing a short caller workflow:
+
+```yaml
+# .github/workflows/hive-ops-pr-audit.yml in the engine repo
+name: HiveOps PR audit
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  audit:
+    uses: saggarsonny-boop/hivebaby/.github/workflows/hive-ops-pr-audit-reusable.yml@main
+    with:
+      slug: <engine-slug>      # "converter" for monorepo apps, repo basename for standalone
+    permissions:
+      pull-requests: write     # PR comment posting
+      contents: read
+```
+
+The reusable workflow:
+
+1. Clones the engine repo's PR branch.
+2. Clones hivebaby for the hive-ops + hive-finalize tooling.
+3. Resolves the **baseline** verdict by running the audit on `main` of the engine repo first.
+4. Runs the audit on the PR branch.
+5. Posts (or updates in place via marker comment) a PR comment with the verdict, the rule-by-rule detail, and a **VERDICT REGRESSION** banner if main was PASS but this PR isn't.
+6. Fails the check if PR-branch verdict is `fail`. Pass/Warn = green check.
+
+This is the canary that prevents UD-Converter-style "regressed PASS → FAIL silently" — every PR sees its own audit and a delta against main before merge.
+
+Engines onboarded as of the inaugural rollout: UD Converter (`saggarsonny-boop/universal-document`), HiveEngineBuilder, HiveAdminSupport, UniversalDocumentInc. Onboard a new engine by committing the caller workflow above to its repo's main branch.
+
 ---
 
 ## VI. Engine Inventory and Compliance Status
@@ -573,7 +632,7 @@ PR before that date will revert to FAIL on the next audit run.
 
 | Engine | Repo | Domain | HiveOps verdict (latest) | Notes |
 |---|---|---|---|---|
-| UD Converter | `universal-document` | converter.hive.baby | ❌ **FAIL** — 48 pass / 4 fail (V04, V18, V19, V23) / 1 override (H21) | Pre-existing V-rule findings; `--write-overrides` proposal scaffolded but not yet committed in the universal-document repo |
+| UD Converter | `universal-document` | converter.hive.baby | ⚠️ **WARN** — 50 pass / 1 warn (V19→2026-06-07) / 0 fail / 4 skip / 2 override (H21, V18) | V04/V18/V23 fixed in universal-document PR #29 (2026-05-08); V19 retains a 30-day warn for `tooltip_tour=pending`. Now audited daily by the cross-repo sweep + per-PR via `hive-ops-pr-audit-reusable.yml`. |
 
 ### External-repo engines (no canonical schema yet)
 

--- a/tools/hive-ops/crossRepoAudit.ts
+++ b/tools/hive-ops/crossRepoAudit.ts
@@ -1,0 +1,308 @@
+#!/usr/bin/env tsx
+// Cross-repo HiveOps audit. Clones each engine listed in
+// tools/hive-ops/external-engines.json and runs runHiveOps against the
+// fresh clone, then emits a Markdown summary suitable for the daily-
+// sweep issue body. Optionally inserts hive_alerts rows on FAIL.
+//
+// Why this exists: dailySweep.ts only sees apps/<engine>/ENGINE_GRAMMAR.md
+// in the hivebaby monorepo. External-repo engines (UD Converter,
+// HiveEngineBuilder, HiveAdminSupport, UniversalDocumentInc, …) were
+// invisible to the sweep — verdict drift went undetected for days at a
+// time. This orchestrator closes that gap by cloning each external
+// engine repo and running the SAME runHiveOps() the in-tree sweep uses,
+// so verdicts are computed identically across repos.
+//
+// Usage:
+//   tsx tools/hive-ops/crossRepoAudit.ts [--registry PATH] [--clone-dir PATH]
+//                                        [--out PATH] [--dry-run]
+//
+// Exit codes:
+//   0 — every external engine ran (verdict may be PASS/WARN/FAIL — that's
+//       reported in the output, not the exit code)
+//   2 — tooling error (registry parse failure, clone failure, etc.)
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runHiveOps, resolveEngineRoot } from "./runner.js";
+import type { EngineReport } from "./types.js";
+
+const AGENT = "hive-ops-cross-repo";
+
+interface ExternalEngine {
+  slug: string;
+  engine_name: string;
+  repo: string;            // owner/name
+  default_branch: string;
+  subdir_pattern: "monorepo" | "root";
+  domain?: string;
+}
+
+interface ExternalRegistry {
+  version: number;
+  engines: ExternalEngine[];
+}
+
+interface CrossRepoArgs {
+  registry: string;
+  cloneDir: string;
+  out: string | null;
+  dryRun: boolean;
+}
+
+interface ExternalResult {
+  engine: ExternalEngine;
+  /** undefined = clone or audit failed before producing a report */
+  report?: EngineReport;
+  errorMessage?: string;
+  durationMs: number;
+}
+
+function parseArgs(argv: string[]): CrossRepoArgs | null {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const args: CrossRepoArgs = {
+    registry: resolve(here, "external-engines.json"),
+    cloneDir: process.env.RUNNER_TEMP ? join(process.env.RUNNER_TEMP, "hive-ops-clones") : "/tmp/hive-ops-clones",
+    out: null,
+    dryRun: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--registry") { args.registry = resolve(argv[++i] ?? ""); continue; }
+    if (a === "--clone-dir") { args.cloneDir = resolve(argv[++i] ?? ""); continue; }
+    if (a === "--out") { args.out = resolve(argv[++i] ?? ""); continue; }
+    if (a === "--dry-run") { args.dryRun = true; continue; }
+    if (a === "-h" || a === "--help") return null;
+    return null;
+  }
+  return args;
+}
+
+function loadRegistry(path: string): ExternalRegistry {
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw) as ExternalRegistry;
+  if (!parsed || typeof parsed !== "object") throw new Error(`registry malformed: ${path}`);
+  if (!Array.isArray(parsed.engines)) throw new Error(`registry missing engines[]: ${path}`);
+  for (const e of parsed.engines) {
+    if (!e.slug || !e.repo || !e.default_branch || !e.subdir_pattern) {
+      throw new Error(`registry entry missing required fields: ${JSON.stringify(e)}`);
+    }
+    if (e.subdir_pattern !== "monorepo" && e.subdir_pattern !== "root") {
+      throw new Error(`registry entry has invalid subdir_pattern: ${e.subdir_pattern}`);
+    }
+  }
+  return parsed;
+}
+
+/** Fresh clone of repo into `<cloneDir>/<repo-basename>`. Replaces any
+ *  existing clone at that path. Uses GITHUB_TOKEN if present (so private
+ *  repos work in CI); otherwise falls back to anonymous HTTPS. */
+function cloneRepo(engine: ExternalEngine, cloneDir: string): string {
+  const repoBasename = engine.repo.split("/").pop()!;
+  const dest = join(cloneDir, repoBasename);
+  if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
+  mkdirSync(cloneDir, { recursive: true });
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const url = token
+    ? `https://x-access-token:${token}@github.com/${engine.repo}.git`
+    : `https://github.com/${engine.repo}.git`;
+  execFileSync(
+    "git",
+    ["clone", "--depth", "1", "--branch", engine.default_branch, url, dest],
+    { stdio: ["ignore", "ignore", "inherit"] },
+  );
+  return dest;
+}
+
+function verdictOf(report: EngineReport): "pass" | "warn" | "fail" {
+  // Same calculus the runner uses: any fail → fail; any warn → warn;
+  // otherwise pass.
+  let hasWarn = false;
+  for (const r of report.rules) {
+    if (r.status === "fail") return "fail";
+    if (r.status === "warn") hasWarn = true;
+  }
+  return hasWarn ? "warn" : "pass";
+}
+
+interface Tally { pass: number; warn: number; fail: number; skip: number; override: number; "n/a": number; }
+
+function tallyOf(report: EngineReport): Tally {
+  const t: Tally = { pass: 0, warn: 0, fail: 0, skip: 0, override: 0, "n/a": 0 };
+  for (const r of report.rules) (t as Record<string, number>)[r.status] = ((t as Record<string, number>)[r.status] ?? 0) + 1;
+  return t;
+}
+
+async function auditOne(
+  engine: ExternalEngine,
+  cloneDir: string,
+): Promise<ExternalResult> {
+  const start = Date.now();
+  let cloneRoot: string;
+  try {
+    cloneRoot = cloneRepo(engine, cloneDir);
+  } catch (err) {
+    return {
+      engine,
+      errorMessage: `clone failed: ${err instanceof Error ? err.message : String(err)}`,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const engineRoot = resolveEngineRoot(cloneRoot, engine.slug);
+  if (!engineRoot) {
+    return {
+      engine,
+      errorMessage: `runner could not find engine "${engine.slug}" under ${cloneRoot} (subdir_pattern=${engine.subdir_pattern})`,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  try {
+    const report = await runHiveOps(engineRoot);
+    return { engine, report, durationMs: Date.now() - start };
+  } catch (err) {
+    return {
+      engine,
+      errorMessage: `audit threw: ${err instanceof Error ? err.message : String(err)}`,
+      durationMs: Date.now() - start,
+    };
+  }
+}
+
+/** Markdown section appended to the daily-sweep issue body. Always
+ *  emitted, even when every engine PASSes — the visibility is the point. */
+export function formatCrossRepoSection(results: ExternalResult[]): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`## External-repo engines (${results.length})`);
+  lines.push("");
+  if (results.length === 0) {
+    lines.push("_Registry is empty. Add entries to `tools/hive-ops/external-engines.json`._");
+    return lines.join("\n");
+  }
+  lines.push("| Engine | Repo | Verdict | Tally (pass/warn/fail/skip/override) | Notes |");
+  lines.push("|---|---|---|---|---|");
+  for (const r of results) {
+    const repoLink = `[\`${r.engine.repo}\`](https://github.com/${r.engine.repo})`;
+    if (r.errorMessage) {
+      lines.push(`| **${r.engine.engine_name}** (\`${r.engine.slug}\`) | ${repoLink} | 🚧 ERROR | — | ${escapeCell(r.errorMessage)} |`);
+      continue;
+    }
+    const v = verdictOf(r.report!);
+    const t = tallyOf(r.report!);
+    const glyph = v === "pass" ? "✅" : v === "warn" ? "⚠️" : "❌";
+    const notes = (r.report!.warnModeRules.length > 0)
+      ? `WARN: ${r.report!.warnModeRules.map(w => `${w.id}→${w.warnUntil}`).join(", ")}`
+      : (v === "fail" ? "see repo audit log for failing rules" : "");
+    lines.push(`| **${r.engine.engine_name}** (\`${r.engine.slug}\`) | ${repoLink} | ${glyph} ${v.toUpperCase()} | ${t.pass}/${t.warn}/${t.fail}/${t.skip}/${t.override} | ${escapeCell(notes)} |`);
+  }
+  lines.push("");
+  const fails = results.filter(r => r.report && verdictOf(r.report) === "fail");
+  if (fails.length > 0) {
+    lines.push(`> **${fails.length} external engine${fails.length === 1 ? "" : "s"} FAILing.** Each FAIL row above has had a tier-2 \`hive_alerts\` regression entry inserted with a cross-link to the engine repo.`);
+  }
+  return lines.join("\n");
+}
+
+function escapeCell(s: string): string { return s.replace(/\|/g, "\\|").replace(/\n/g, " "); }
+
+/** Insert a tier-2 hive_alerts row for an external engine FAIL. Best-
+ *  effort: psql + DATABASE_URL; otherwise prints. */
+function insertFailAlert(r: ExternalResult): void {
+  if (!r.report) return;
+  const dbUrl = process.env.DATABASE_URL;
+  const subject = `HiveOps: external engine ${r.engine.engine_name} regressed to FAIL`;
+  const t = tallyOf(r.report);
+  const body = [
+    `Engine:     ${r.engine.engine_name} (${r.engine.slug})`,
+    `Repo:       https://github.com/${r.engine.repo}`,
+    `Tally:      pass=${t.pass} warn=${t.warn} fail=${t.fail} skip=${t.skip} override=${t.override} n/a=${t["n/a"]}`,
+    "",
+    "Cross-repo daily sweep detected a verdict regression. The engine's",
+    "previous verdict was not WARN/FAIL on the prior sweep; this run",
+    "found at least one rule in `fail`. See the engine repo for failing-",
+    "rule detail (or run `tsx tools/hive-ops/cli.ts <slug> --repo <clone>`",
+    "locally).",
+    "",
+    "Action: investigate the regression in the engine repo and either",
+    "fix the underlying issue or add a documented `mode: warn` override",
+    "with `warn_until` per the schema in HIVE_CONSTITUTION.md §V.",
+  ].join("\n");
+  if (!dbUrl) {
+    console.log(`[cross-repo-audit] (no DATABASE_URL — would insert) tier=2 subject=${subject}`);
+    return;
+  }
+  const actionUrl = `https://github.com/${r.engine.repo}`;
+  const sql =
+    `INSERT INTO hive_alerts (tier, agent, subject, body, action_required, action_url) ` +
+    `VALUES (2, ${dollarQuote(AGENT)}, ${dollarQuote(subject)}, ${dollarQuote(body)}, true, ${dollarQuote(actionUrl)});`;
+  execFileSync("psql", [dbUrl, "-v", "ON_ERROR_STOP=1", "-c", sql], { stdio: "inherit" });
+}
+
+function dollarQuote(s: string): string {
+  let tag = "tag";
+  while (s.includes(`$${tag}$`)) tag = "t" + Math.random().toString(36).slice(2, 8);
+  return `$${tag}$${s}$${tag}$`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args) {
+    console.error("Usage: tsx tools/hive-ops/crossRepoAudit.ts [--registry PATH] [--clone-dir PATH] [--out PATH] [--dry-run]");
+    process.exit(2);
+  }
+  let registry: ExternalRegistry;
+  try {
+    registry = loadRegistry(args.registry);
+  } catch (err) {
+    console.error(`registry load failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(2);
+  }
+
+  console.log(`cross-repo-audit: ${registry.engines.length} engines registered`);
+  const results: ExternalResult[] = [];
+  for (const engine of registry.engines) {
+    console.log(`  → ${engine.engine_name} (${engine.repo})`);
+    const r = await auditOne(engine, args.cloneDir);
+    if (r.errorMessage) {
+      console.log(`    ERROR ${r.errorMessage}`);
+    } else {
+      const v = verdictOf(r.report!);
+      const t = tallyOf(r.report!);
+      console.log(`    ${v.toUpperCase()} (${t.pass}/${t.warn}/${t.fail}/${t.skip}/${t.override})  in ${r.durationMs}ms`);
+    }
+    results.push(r);
+  }
+
+  const md = formatCrossRepoSection(results);
+  if (args.out) {
+    writeFileSync(args.out, md);
+    console.log(`cross-repo-audit: section written → ${args.out}`);
+  } else {
+    process.stdout.write("\n" + md + "\n");
+  }
+
+  if (!args.dryRun) {
+    for (const r of results) {
+      if (r.report && verdictOf(r.report) === "fail") {
+        insertFailAlert(r);
+      }
+    }
+  }
+
+  process.exit(0);
+}
+
+const isCli =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  /crossRepoAudit\.(ts|js|mjs)$/.test(process.argv[1]);
+if (isCli) {
+  main().catch((err) => {
+    console.error("hive-ops cross-repo-audit crashed:", err);
+    process.exit(2);
+  });
+}

--- a/tools/hive-ops/external-engines.json
+++ b/tools/hive-ops/external-engines.json
@@ -1,0 +1,38 @@
+{
+  "$comment": "Registry of external-repo Hive engines audited by HiveOps daily-sweep cross-repo pass and consumed by the reusable hive-ops-pr-audit-reusable.yml workflow. Hivebaby-resident engines (apps/parkback, hive-imr, hive-aestheticbestie, hive-hivephoto) are NOT listed here — they're already covered by the in-tree daily sweep + .github/workflows/hive-ops.yml. To add a new external engine: append an entry, push the corresponding caller workflow into the engine repo's .github/workflows/hive-ops-pr-audit.yml referencing this slug.",
+  "version": 1,
+  "engines": [
+    {
+      "slug": "converter",
+      "engine_name": "UDConverter",
+      "repo": "saggarsonny-boop/universal-document",
+      "default_branch": "main",
+      "subdir_pattern": "monorepo",
+      "domain": "converter.hive.baby"
+    },
+    {
+      "slug": "hive-engine-builder",
+      "engine_name": "HiveEngineBuilder",
+      "repo": "saggarsonny-boop/hive-engine-builder",
+      "default_branch": "main",
+      "subdir_pattern": "root",
+      "domain": "heb.hive.baby"
+    },
+    {
+      "slug": "hive-support",
+      "engine_name": "HiveAdminSupport",
+      "repo": "saggarsonny-boop/hive-support",
+      "default_branch": "main",
+      "subdir_pattern": "root",
+      "domain": "support.hive.baby"
+    },
+    {
+      "slug": "ud-inc",
+      "engine_name": "UniversalDocumentInc",
+      "repo": "saggarsonny-boop/ud-inc",
+      "default_branch": "main",
+      "subdir_pattern": "root",
+      "domain": "universaldocument.hive.baby"
+    }
+  ]
+}

--- a/tools/hive-ops/runner.ts
+++ b/tools/hive-ops/runner.ts
@@ -26,12 +26,25 @@ import { ruleApplies, inapplicableReason } from "./applicability.js";
 /** Resolve an engine slug to its on-disk root. Search order:
  *  1. <repoRoot>/apps/<slug>
  *  2. <repoRoot>/<slug>            (standalone repos cloned alongside)
- *  Returns null if neither resolves. */
+ *  3. <repoRoot>                   (the repo root IS the engine root —
+ *                                   true for standalone external repos
+ *                                   like hive-engine-builder, ud-inc,
+ *                                   hive-support where the entire repo
+ *                                   is one engine. Required for cross-
+ *                                   repo audit; engineSlug is derived
+ *                                   from basename(repoRoot) which won't
+ *                                   match the requested slug literally
+ *                                   for clones with arbitrary directory
+ *                                   names — but the manifest itself
+ *                                   identifies the engine.)
+ *  Returns null if none resolve. */
 export function resolveEngineRoot(repoRoot: string, slug: string): string | null {
   const inApps = join(repoRoot, "apps", slug);
   if (existsSync(inApps)) return inApps;
   const standalone = join(repoRoot, slug);
   if (existsSync(standalone)) return standalone;
+  // Repo root itself with manifest at root.
+  if (existsSync(join(repoRoot, "ENGINE_GRAMMAR.md"))) return repoRoot;
   return null;
 }
 


### PR DESCRIPTION
## Summary

Closes the silent-regression gap that PR #131 surfaced: external-repo Hive engines (UD Converter, HiveEngineBuilder, HiveAdminSupport, UniversalDocumentInc, …) were invisible to the daily HiveOps sweep, so verdict drift went undetected for days at a time.

This PR adds two complementary guardrails:

- **Cross-repo daily audit** — `tools/hive-ops/crossRepoAudit.ts` clones each engine listed in `tools/hive-ops/external-engines.json`, runs the same `runHiveOps()` the in-tree sweep uses, and merges results into the daily issue body under a new `## External-repo engines` section. Tier-2 `hive_alerts` entries fire on FAIL.
- **Per-PR audit guardrail** — `.github/workflows/hive-ops-pr-audit-reusable.yml` is a reusable workflow that engine repos opt into via a short caller workflow. It computes a baseline verdict on the engine repo's `main`, audits the PR branch, and posts/updates an in-place PR comment marked by the engine slug. **VERDICT REGRESSION** banner if main was PASS but this PR isn't. Fails the check on verdict=fail.

Implementation detail: `runner.ts` `resolveEngineRoot()` now also accepts the repo root itself (when `ENGINE_GRAMMAR.md` lives at the root) — required for standalone external repos like hive-engine-builder, hive-support, ud-inc.

§V of the constitution gets two new subsections, `[CROSS_REPO_AUDIT]` and `[PR_GUARDRAIL]`. §VI's UD Converter line is updated to its actual post-#29 state (WARN, not FAIL — the table had drifted exactly the way this PR fixes).

## On the "current UD Converter FAIL" the brief asked me to fix

It isn't currently FAIL. universal-document PR #29 (merged 2026-05-08) fixed V04/V18/V23. As of this audit run UD Converter is **WARN** (50 pass / 1 warn / 0 fail / 4 skip / 2 override) — the single warn is V19, with a 30-day warn-mode override documenting `tooltip_tour=pending` and an expiry of 2026-06-07. The constitution §VI was carrying stale FAIL data, which is the symptom this PR solves: the daily cross-repo sweep will keep §VI honest going forward.

## Inaugural rollout

External engine registry seeded with the four LIVE-with-active-PRs engines flagged in PR #131:

- saggarsonny-boop/universal-document (UDConverter — apps/converter)
- saggarsonny-boop/hive-engine-builder (HiveEngineBuilder)
- saggarsonny-boop/hive-support (HiveAdminSupport)
- saggarsonny-boop/ud-inc (UniversalDocumentInc)

Caller workflows for these four repos commit as separate single-file changes in each repo's main branch *after* this PR merges (so the reusable workflow exists at `saggarsonny-boop/hivebaby/.github/workflows/hive-ops-pr-audit-reusable.yml@main`).

## Test plan

- [x] `tsx tools/hive-ops/crossRepoAudit.ts --dry-run` ran end-to-end against all 4 registered engines: UDConverter→WARN, HEB/Support/UDInc→FAIL (legacy grammar — UCOC issues already filed in the prior session). Output Markdown table matches the issue-body schema.
- [x] `resolveEngineRoot()` extension verified on `/tmp/heb-clone` (a standalone clone): runner finds the engine at the repo root and produces a verdict.
- [x] `tsx tools/hive-ops/dailySweep.ts --dry-run` still works — no regression in the in-tree path.
- [x] Both new YAML files parse with `python3 -c "import yaml; yaml.safe_load(...)"`.
- [ ] Daily-sweep workflow validated end-to-end on the next 09:00 UTC cron firing (or earlier via `gh workflow run hive-ops-daily-sweep.yml -f dry_run=true`).
- [ ] PR-audit reusable workflow validated by the first caller-workflow PR in `saggarsonny-boop/universal-document` once this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
