### PR TITLE
feat(hive-ops): add HIVEOPS_CROSS_REPO_TOKEN for private-repo audit visibility

### DIFF
--- a/.github/workflows/hive-ops-daily-sweep.yml
+++ b/.github/workflows/hive-ops-daily-sweep.yml
@@ -31,14 +31,21 @@ name: HiveOps — daily warn-mode sweep + cross-repo audit
 #   pull-requests: write  — reserved; not used today (commits go direct)
 #
 # Secrets / tokens:
-#   DATABASE_URL          — Postgres connection string for hive_alerts
-#                           (already in repo secrets per ci-doctor + the
-#                           query-hive-alerts.yml workflow)
-#   GITHUB_TOKEN          — default token; used by crossRepoAudit.ts to
-#                           clone external Hive engine repos. The default
-#                           token only has read access to the org's public
-#                           repos, which is exactly what we need (no
-#                           write back to external repos from the sweep).
+#   DATABASE_URL                — Postgres connection string for hive_alerts
+#                                 (already in repo secrets per ci-doctor +
+#                                 the query-hive-alerts.yml workflow)
+#   HIVEOPS_CROSS_REPO_TOKEN    — optional fine-grained PAT, scoped to read
+#                                 (Contents + Metadata + Pull-requests) every
+#                                 repo in saggarsonny-boop. When present, the
+#                                 cross-repo audit can clone PRIVATE engine
+#                                 repos (hive-engine-builder, etc.) instead
+#                                 of surfacing them as ERROR rows. Rotates
+#                                 yearly per CLAUDE.md §E [PAT_ROTATION_HIVEOPS].
+#                                 If absent, audit gracefully degrades —
+#                                 public repos still audit correctly.
+#   GITHUB_TOKEN                — default token; used by crossRepoAudit.ts
+#                                 when HIVEOPS_CROSS_REPO_TOKEN is unset.
+#                                 Reads public org repos only.
 
 on:
   schedule:
@@ -118,9 +125,15 @@ jobs:
       - name: Run cross-repo audit (external engines)
         id: cross
         env:
-          # GITHUB_TOKEN gives the cloner read access to
-          # saggarsonny-boop's public repos. DATABASE_URL is required
-          # for tier-2 FAIL alerts.
+          # HIVEOPS_CROSS_REPO_TOKEN: fine-grained PAT scoped to the
+          # saggarsonny-boop org with Contents + Metadata + Pull-requests
+          # read on all repos. When set, the audit can clone PRIVATE
+          # engine repos (hive-engine-builder is currently the only one).
+          # When unset, the audit falls back to GITHUB_TOKEN (public repos
+          # only) and surfaces private repos as ERROR rows. The fallback
+          # in tools/hive-ops/crossRepoAudit.ts:cloneRepo() does the
+          # actual selection.
+          HIVEOPS_CROSS_REPO_TOKEN: ${{ secrets.HIVEOPS_CROSS_REPO_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,6 +405,28 @@ Update at the same time you check checklist items:
 - `registry/billing-reconciliation.md` — monthly COGS estimate.
 - `docs/engine-archives/<engine-slug>/` — archived spec (`ENGINE_GRAMMAR.md`, `README.md`, `test-station-slot.md`).
 
+### E12. `HIVEOPS_CROSS_REPO_TOKEN` — annual rotation `[PAT_ROTATION_HIVEOPS]`
+
+The cross-repo daily sweep + per-PR audit guardrail (`tools/hive-ops/crossRepoAudit.ts` + `.github/workflows/hive-ops-daily-sweep.yml`) clone external engine repos to run `runHiveOps()` against fresh checkouts. The default Actions `GITHUB_TOKEN` reads only public repos; **private engine repos (currently `saggarsonny-boop/hive-engine-builder`) surface as `🚧 ERROR` rows without a fine-grained PAT.**
+
+The PAT lives in hivebaby Actions secrets as `HIVEOPS_CROSS_REPO_TOKEN`. Required attributes:
+
+- **Resource owner:** `saggarsonny-boop`
+- **Repository access:** All repositories
+- **Repository permissions:** Contents (Read), Metadata (Read), Pull requests (Read) — everything else **No access**.
+- **Expiration:** 1 year. Rotation date is recorded here on issue.
+
+**Rotation: yearly.** GitHub doesn't support programmatic PAT minting (POST endpoints return 404 on user-self-creation as of January 2026), so rotation is the one HiveOps-pipeline operation that genuinely requires a dashboard step. When rotation is due:
+
+1. Open https://github.com/settings/personal-access-tokens/new with the attributes above.
+2. Paste the new token: `gh secret set HIVEOPS_CROSS_REPO_TOKEN --repo saggarsonny-boop/hivebaby --body "$NEW_VALUE"`.
+3. Trigger a manual dry-run sweep to confirm: `gh workflow run hive-ops-daily-sweep.yml -f dry_run=true`. The cross-repo step should report all engines (private included) with real verdicts, no `ERROR` rows.
+4. Update the rotation-due date here.
+
+**Current rotation due:** _2027-05-09_ (initial provision 2026-05-09).
+
+The workflow gracefully degrades when the secret is unset or expired — public engines still audit; private engines just report `🚧 ERROR`. So rotation drift produces visible signal in the daily issue, not silent failure.
+
 ---
 
 ## F. hive.baby PLANET — THE FRONT DOOR

--- a/tools/hive-ops/crossRepoAudit.ts
+++ b/tools/hive-ops/crossRepoAudit.ts
@@ -96,14 +96,24 @@ function loadRegistry(path: string): ExternalRegistry {
 }
 
 /** Fresh clone of repo into `<cloneDir>/<repo-basename>`. Replaces any
- *  existing clone at that path. Uses GITHUB_TOKEN if present (so private
- *  repos work in CI); otherwise falls back to anonymous HTTPS. */
+ *  existing clone at that path. Token preference order:
+ *    1. HIVEOPS_CROSS_REPO_TOKEN — fine-grained PAT scoped to read every
+ *       saggarsonny-boop engine repo (public + private). Set as a
+ *       hivebaby Actions secret; rotates yearly per CLAUDE.md §E.
+ *    2. GITHUB_TOKEN  — workflow's auto-provided token. Reads public
+ *       repos only; private engine repos surface as ERROR rows (graceful
+ *       degradation, not a tooling failure).
+ *    3. GH_TOKEN      — local-dev fallback (operator's gh CLI auth).
+ *  Anonymous HTTPS only on public repos with no token at all. */
 function cloneRepo(engine: ExternalEngine, cloneDir: string): string {
   const repoBasename = engine.repo.split("/").pop()!;
   const dest = join(cloneDir, repoBasename);
   if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
   mkdirSync(cloneDir, { recursive: true });
-  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const token =
+    process.env.HIVEOPS_CROSS_REPO_TOKEN ??
+    process.env.GITHUB_TOKEN ??
+    process.env.GH_TOKEN;
   const url = token
     ? `https://x-access-token:${token}@github.com/${engine.repo}.git`
     : `https://github.com/${engine.repo}.git`;


### PR DESCRIPTION
## Summary

Wires `HIVEOPS_CROSS_REPO_TOKEN` into the cross-repo HiveOps pipeline shipped in PRs #133 / #136 / #138, so private engine repos (currently `saggarsonny-boop/hive-engine-builder`) can be audited instead of surfacing as `🚧 ERROR` rows in the daily sweep issue.

- `tools/hive-ops/crossRepoAudit.ts` — token-pick chain is now `HIVEOPS_CROSS_REPO_TOKEN ?? GITHUB_TOKEN ?? GH_TOKEN`.
- `.github/workflows/hive-ops-daily-sweep.yml` — surfaces the new secret to the cross-repo step's `env`. Header docs updated to describe both paths.
- `CLAUDE.md` §E12 `[PAT_ROTATION_HIVEOPS]` — new subsection with the dashboard URL, required PAT attributes (Contents / Metadata / Pull-requests = Read, all-repos, 1y expiry), the rotation procedure, and the current expiry date (**2027-05-09**).
- `MEMORY.md` — pointer to a new `reference_pat_rotation_hiveops.md` so future sessions remember the yearly rotation cadence.

## Why a separate, manually-minted PAT and not just the workflow `GITHUB_TOKEN`

The default Actions `GITHUB_TOKEN` is scoped to its own repository, so it can't read sibling repos in the org. Reading PRIVATE engine repos requires either a PAT or a GitHub App. PAT was the user's chosen mechanism (see the brief).

GitHub does not expose a programmatic PAT-creation endpoint:

```
$ gh api user/personal-access-tokens
{"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}

$ gh api -X POST user/personal-access-tokens -f name='HIVEOPS_CROSS_REPO_TOKEN'
{"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}
```

So the PAT itself is minted via dashboard. This PR is the wiring — once the secret is set with a single `gh secret set`, the daily sweep flips `hive-engine-builder` from ERROR to a real verdict on its next run.

## Test plan

- [x] `tsx tools/hive-ops/crossRepoAudit.ts --dry-run` still produces the cross-repo Markdown table with the inaugural 4 engines. Token absence path is unchanged from PR #133.
- [x] Both edited files parse (YAML + TypeScript via `npm install` + `tsx`).
- [ ] Once `HIVEOPS_CROSS_REPO_TOKEN` is set as a hivebaby Actions secret, run `gh workflow run hive-ops-daily-sweep.yml --repo saggarsonny-boop/hivebaby -f dry_run=true` and confirm the cross-repo section shows `hive-engine-builder` with a real verdict (FAIL on legacy grammar) and no `ERROR` row.
- [ ] Bump `CLAUDE.md` §E12 "Current rotation due" date when the secret rotates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
