### PR TITLE
docs: Constitution §VII Queen Bee Architecture + [QUEEN_BEE_LOCATION] pointer rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,9 @@ Sonny's standing preference is **$0/month operating cost**. When a free path and
 ### B17. Machine over human `[MACHINE_OVER_HUMAN]`
 When a task can be done by machine OR by Sonny, the machine does it. Strengthens B12 with an explicit ordering: (1) default — CC executes via API / CLI / scripted dashboard call; (2) fallback — CC retrieves missing tokens from GH Actions secrets, generates one with `openssl rand`, or scripts the missing capability; (3) last resort — CC asks Sonny to perform a UI action ONLY when CC has explicit evidence the API doesn't support the operation (linked docs, attempted call with actual error, known vendor limitation). "I think the API doesn't have this" is not evidence. Creatively work around tooling limitations rather than offload to human hands. When a UI step is genuinely required, name the exact URL + exact field + exact value. See [Constitution §IV "Machine over human"](docs/HIVE_CONSTITUTION.md#machine-over-human).
 
+### B18. Before any engine work, check Queen Bee architecture `[QUEEN_BEE_LOCATION]`
+Before scaffolding safety enforcement, output schema validation, language detection, compliance audits, or cross-engine reachability monitoring into any engine, read [Constitution §VII "Queen Bee Architecture"](docs/HIVE_CONSTITUTION.md#vii-queen-bee-architecture--queen_bee_location). The Queen Bee runtime governance engine at `https://github.com/saggarsonny-boop/queen-bee` (deployed at `queenbee.hive.baby`) already provides these via `POST /api/govern`, and engines should inherit by registering in `queen-bee/lib/registry.ts` rather than duplicating QB's functionality. Honest gap: no engine actually calls QB yet — the inheritance pattern is established in code but not in production, so the first engine to wire it is also documenting the wiring pattern for the next.
+
 ---
 
 ## C. ENGINEERING STANDARDS
@@ -217,7 +220,7 @@ Engine-specific Stripe price IDs follow `STRIPE_PRICE_<TIER>_<INTERVAL>` (e.g. `
 Every engine declares `cost_profile` in its frontmatter under one of `zero_marginal | low_marginal | medium_marginal | high_marginal`. The profile drives the free-tier rules in §A. HiveOps will eventually enforce that the declared profile matches the engine's actual rate-limit implementation (v0.3 candidate, see [Constitution §III](docs/HIVE_CONSTITUTION.md#iii-pricing-and-cost-profiles)).
 
 ### C15. Production copy hygiene
-- **No "coming soon" / "not yet" / "TODO"** placeholders in production user-facing copy. Hide absent features rather than advertise them as inactive (the bait-and-switch UX is worse than absence — see [Constitution §VII](docs/HIVE_CONSTITUTION.md#coming-soon-labels-in-production--bait-and-switch-ux) on UD Converter PR #11). v0.3 of HiveOps will grep `app/**/*.tsx` for these tokens and fail.
+- **No "coming soon" / "not yet" / "TODO"** placeholders in production user-facing copy. Hide absent features rather than advertise them as inactive (the bait-and-switch UX is worse than absence — see [Constitution §VIII](docs/HIVE_CONSTITUTION.md#coming-soon-labels-in-production--bait-and-switch-ux) on UD Converter PR #11). v0.3 of HiveOps will grep `app/**/*.tsx` for these tokens and fail.
 - **No third-party analytics** (GA, Hotjar, Segment, Mixpanel). Plausible cloud / Umami self-hosted / homemade Neon counter only.
 - **Cite real sources visibly** when displaying third-party data; never fabricate.
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -35,7 +35,7 @@ WebKit; until then, the rule is enforced by review + the engine's own
 `launch_checklist_state.test_slot` boolean.
 
 **Source:** Locked 2026-05-06. Originated from ParkBack PR #70 iOS Safari
-render-only-the-compass bug (see Constitution §VII).
+render-only-the-compass bug (see Constitution §VIII).
 
 **Constitution reference:** [§IV "Device verification mandatory"](docs/HIVE_CONSTITUTION.md#device-verification-mandatory).
 
@@ -146,7 +146,7 @@ the From-format dropdown showed 234 potential output formats but only
 ~30 were actually implemented.
 
 **Constitution reference:** [§II "Production copy hygiene"](docs/HIVE_CONSTITUTION.md#production-copy-hygiene)
-+ [§VII "Coming soon labels in production"](docs/HIVE_CONSTITUTION.md#coming-soon-labels-in-production--bait-and-switch-ux).
++ [§VIII "Coming soon labels in production"](docs/HIVE_CONSTITUTION.md#coming-soon-labels-in-production--bait-and-switch-ux).
 
 ---
 
@@ -166,7 +166,7 @@ tracked in universal-document issue #13. Free-tier UD Converter capped at
 memory.
 
 **Constitution reference:** [§V "HiveOps Governance"](docs/HIVE_CONSTITUTION.md#v-hiveops-governance)
-+ [§VII "CI workflow only installed hive-ops deps"](docs/HIVE_CONSTITUTION.md#ci-workflow-only-installed-hive-ops-deps--install-all-consumed-packages).
++ [§VIII "CI workflow only installed hive-ops deps"](docs/HIVE_CONSTITUTION.md#ci-workflow-only-installed-hive-ops-deps--install-all-consumed-packages).
 
 ---
 
@@ -185,7 +185,7 @@ budget choice.
 **Source:** Locked 2026-05-06. Architectural decision recorded so future
 sessions don't propose Vercel Pro upgrade as a path.
 
-**Constitution reference:** [§VII "UD Converter Vercel edge body limit"](docs/HIVE_CONSTITUTION.md#ud-converter-vercel-edge-body-limit--free-tier-4-mb-cap).
+**Constitution reference:** [§VIII "UD Converter Vercel edge body limit"](docs/HIVE_CONSTITUTION.md#ud-converter-vercel-edge-body-limit--free-tier-4-mb-cap).
 
 ---
 
@@ -205,7 +205,7 @@ lands.
 
 **Source:** Locked 2026-05-06. Originated from PR #17 (universal-document).
 
-**Constitution reference:** [§VII "@hive/onboarding inlined in universal-document"](docs/HIVE_CONSTITUTION.md#hiveonboarding-inlined-in-universal-document--cross-tree-react-deduplication).
+**Constitution reference:** [§VIII "@hive/onboarding inlined in universal-document"](docs/HIVE_CONSTITUTION.md#hiveonboarding-inlined-in-universal-document--cross-tree-react-deduplication).
 
 ---
 
@@ -333,6 +333,22 @@ CC adopts existing patterns from the registry when applicable, rather than re-im
 
 ---
 
+### Rule #36 — `[QUEEN_BEE_LOCATION]`
+
+**Title:** Queen Bee runtime governance engine lives at `saggarsonny-boop/queen-bee` → `queenbee.hive.baby`. Inherit from it before re-implementing safety/schema/language/audit.
+
+**Body:** The runtime governance engine is at `https://github.com/saggarsonny-boop/queen-bee`, deployed at `queen-bee-v1.vercel.app` with public DNS at `queenbee.hive.baby`. It exposes `POST /api/govern` for engine output validation + envelope stamping, plus `GET /api/registry`, `GET /api/audit`, `GET /api/health`. Engines inherit by registering their config in `queen-bee/lib/registry.ts` and calling `/api/govern` from their server routes — there is no shared package yet; integration is HTTP. The Master Grappler (`lib/grappler.ts`) handles schema validation, safety enforcement (`lib/safety.ts`), language detection, and envelope stamping in one pass. Schema types and required fields are in `lib/schemas.ts`.
+
+Before scaffolding output schema validation, safety enforcement, language detection, compliance audits, or cross-engine reachability monitoring into a new engine, check what QB already provides — if the capability is in QB, register the engine and call the endpoint instead of re-implementing.
+
+Honest gap as of 2026-05-08: no engine actually calls `/api/govern` in production yet. The 14 engines in `queen-bee/lib/registry.ts` are *registered* (so QB knows about them and audits their reachability), not *governed* (they don't route outputs through QB). Aspirational references to "Hive Core", "Foundry", "Factory", or "27 adoption amplifiers" do not correspond to anything in any repo and should be treated as legacy talk pending evidence.
+
+**Source:** Locked 2026-05-08. Originated from a discovery sweep across hivebaby, queen-bee, universal-document, and standalone engine repos to make QB findable from every future CC session — without this rule the queen-bee repo is reachable only by name search and CC has historically re-implemented governance functions that QB already provides.
+
+**Constitution reference:** [§VII "Queen Bee Architecture"](docs/HIVE_CONSTITUTION.md#vii-queen-bee-architecture--queen_bee_location).
+
+---
+
 ## Earlier-session rules — pre-2026-05-06
 
 ### `[ID_PROTECTION]`
@@ -389,7 +405,7 @@ logs automatically on any 500 or deployment failure.
 PR #2 Anthropic whole-PDF fallback timeout.
 
 **Constitution reference:** [§IV "Diagnostic rule"](docs/HIVE_CONSTITUTION.md#diagnostic-rule)
-+ [§VII "Anthropic whole-PDF fallback timeout"](docs/HIVE_CONSTITUTION.md#anthropic-whole-pdf-fallback-timeout--diagnose-first-rule).
++ [§VIII "Anthropic whole-PDF fallback timeout"](docs/HIVE_CONSTITUTION.md#anthropic-whole-pdf-fallback-timeout--diagnose-first-rule).
 
 ---
 
@@ -413,7 +429,7 @@ the prompt.
 key paste leak incident.
 
 **Constitution reference:** [§II "Canonical secret names"](docs/HIVE_CONSTITUTION.md#canonical-secret-names)
-+ [§VII "Anthropic API key paste leak"](docs/HIVE_CONSTITUTION.md#anthropic-api-key-paste-leak--never-paste-secrets-in-cc-chat).
++ [§VIII "Anthropic API key paste leak"](docs/HIVE_CONSTITUTION.md#anthropic-api-key-paste-leak--never-paste-secrets-in-cc-chat).
 
 ---
 
@@ -511,7 +527,7 @@ updates require a PR; no direct-to-main, no exceptions.
 **Source:** Standing rule from prior sessions; locked when Constitution
 shipped 2026-05-06 (PR #91).
 
-**Constitution reference:** [§VIII "Update Mechanism"](docs/HIVE_CONSTITUTION.md#viii-update-mechanism).
+**Constitution reference:** [§IX "Update Mechanism"](docs/HIVE_CONSTITUTION.md#ix-update-mechanism).
 
 ---
 

--- a/docs/HIVE_CONSTITUTION.md
+++ b/docs/HIVE_CONSTITUTION.md
@@ -5,7 +5,7 @@
 > operational mirror — runtime-actionable subset only. **Read this for
 > the *why*; read CLAUDE.md for the *what to do right now*.**
 >
-> Update mechanism is in §VIII. Don't edit CLAUDE.md without
+> Update mechanism is in §IX. Don't edit CLAUDE.md without
 > reflecting the change here first.
 
 ---
@@ -195,7 +195,7 @@ Hive deliberately bypasses.
 - **No "coming soon" / "not yet" / "TODO" placeholders in production
   user-facing copy.** If a feature isn't ready, hide it entirely
   rather than advertise it as inactive (the bait-and-switch UX is
-  worse than absence — see UD Converter PR #11 lessons in §VII).
+  worse than absence — see UD Converter PR #11 lessons in §VIII).
 - **No third-party analytics** (Google Analytics, Hotjar, Segment,
   Mixpanel, etc.). Plausible (privacy-respecting, no cookies) is
   acceptable for engines that already have it; the existing
@@ -392,7 +392,7 @@ or correct.
 Android Chrome (or accurate device profiles in WebKit / Chromium
 headless).** Vercel CI green is **not sufficient.** Past iOS Safari
 regressions (PR #70 in ParkBack — render-only-the-compass bug — see
-§VII) shipped past green CI because the production iOS render was
+§VIII) shipped past green CI because the production iOS render was
 never verified.
 
 The verification proof points are:
@@ -670,7 +670,80 @@ the full ecosystem table.
 
 ---
 
-## VII. Architecture Decisions and Lessons Learned
+## VII. Queen Bee Architecture  `[QUEEN_BEE_LOCATION]`
+
+Queen Bee is the runtime governance engine of the Hive ecosystem — the Master Grappler in production. This section is the canonical pointer for every CC session: before scaffolding safety, schema validation, language detection, or audit dashboards into a new engine, check what Queen Bee already provides and inherit from it instead of re-implementing.
+
+### Where Queen Bee lives
+
+- **Repo:** `saggarsonny-boop/queen-bee` — `https://github.com/saggarsonny-boop/queen-bee`
+- **Vercel deployment:** `queen-bee-v1.vercel.app` (live, HTTP/2 200)
+- **Public domain:** `queenbee.hive.baby` (DNS wired; CNAME to Vercel)
+- **Stack:** Next.js 16.2.4 + React 19.2.4 + TypeScript + Anthropic SDK
+- **Status (per its `ENGINE_GRAMMAR.md`):** Building, governance engine in progress
+- **CLAUDE.md in the queen-bee repo:** points to `AGENTS.md` (which contains generic Next.js notes, not QB-specific guidance) — when working in queen-bee, read this Constitution section first.
+
+### What's actually built
+
+Confirmed by reading the queen-bee repo on 2026-05-08:
+
+| Component | File | Status |
+|---|---|---|
+| Master Grappler | `lib/grappler.ts` | Implemented. Schema field validation, safety check, language detection (zh/ar/ja/ru/en heuristic), QB envelope stamping with version `0.2.0`. |
+| Engine registry | `lib/registry.ts` | 14 engines registered with `id, name, domain, status, tone, safety, schema, multilingual, description`. |
+| Safety enforcement | `lib/safety.ts` | Tiered rules: universal blocks (suicide/self-harm, weapons synthesis, CSAM); standard blocks; medical-flag patterns; elevated-flag patterns; per-tier disclaimer requirements. |
+| Output schemas | `lib/schemas.ts` | Required-field map for 15 schema types (`time-response`, `clarity-response`, `scenario-response`, `coaching-response`, `health-log-response`, `governance-response`, `moon-response`, `lookup-response`, `builder-response`, `conversion-response`, `reader-response`, `creator-response`, `validator-response`, `secret-response`, `generic`). |
+| Public API | `app/api/` | `POST /api/govern` (validate + stamp), `GET /api/registry`, `GET /api/audit` (dashboard data), `GET /api/health` (live engine reachability). |
+| Audit dashboard | `app/page.tsx` | Live UI at `queen-bee-v1.vercel.app` rendering reachability + governed-flag for every registered engine. |
+| Onboarding stack | `components/{AutoDemo,FirstVisitCard,TooltipTour}.tsx` | Implemented. |
+
+### How engines inherit from Queen Bee
+
+The mechanism is **HTTP, not a package**. An engine inherits by:
+
+1. **Registering in `queen-bee/lib/registry.ts`** with `{id, name, domain, status, tone, safety, schema, multilingual, description}`. The engine's slug becomes the `engineId` it sends to the Grappler.
+2. **Calling `POST https://queenbee.hive.baby/api/govern`** with `{engineId, input, content}` before returning each output. QB returns either a stamped envelope (`200`) or a failure report with errors (`422`).
+3. **Returning the envelope** to the client unchanged — it carries `safe`, `governed`, `language`, `flags`, `version`, `timestamp` fields the client surface can render.
+
+There is no shared library yet — engines that adopt this call the HTTP endpoint directly. This keeps QB out of every engine's bundle but means each engine has to wire its own fetch call and handle QB unavailability. A future `@hive/grappler-client` package becomes plausible once two or more engines are calling `/api/govern` in production.
+
+### Adoption status — honest gap report
+
+As of 2026-05-08, **no Hive engine in this monorepo or in any standalone engine repo actually calls `/api/govern` in production**. Verified by `grep -r "queenbee\.|api/govern|queen-bee-v1" --include="*.ts" --include="*.tsx"` across `hivebaby/apps/`, `hivebaby/packages/`, `universal-document/apps/`, and the standalone engine repos. Queen Bee is deployed and ready, but engines still embed their own safety/schema logic.
+
+The 14 engines listed in `queen-bee/lib/registry.ts` are *registered* (so QB knows about them and can audit their reachability), not *governed* (they don't route their outputs through QB). This is visible in the live audit feed at `queen-bee-v1.vercel.app/api/health`: `governed: true` is the dashboard's reachability check, not proof that the engine called QB.
+
+### Things described elsewhere that don't exist yet
+
+When earlier conversations or notes reference these, treat them as aspirational pending evidence to the contrary:
+
+- **"27 adoption amplifiers"** — no canonical list of 27 amplifiers exists in any repo. The closest match is HiveOps' `ADOPTION_AMPLIFIERS` H-rule category, which currently has two rules (H24, H25 — manifest registration in layout + viewport meta). When a future PR introduces a true list of amplifiers, link it from this section.
+- **"Hive Core" / "Foundry" / "Factory"** — no code, no docs, no anchors anywhere in `hivebaby`, `queen-bee`, `universal-document`, or any engine repo on 2026-05-08. If these were ever shipped, they've since been deleted or renamed; the runtime governance work that those names were probably reaching for is the Master Grappler in the queen-bee repo.
+
+### Relationship to §V "Queen Bee Substrate Registry" `[QUEEN_BEE_SUBSTRATES]`
+
+The Substrate Registry (§V) and the Queen Bee Engine (this section) are **distinct artefacts that share a name**.
+
+- The Substrate Registry is a markdown ledger at `docs/QUEEN_BEE_SUBSTRATES.md` listing 13 reusable code patterns (operator auth, audit dashboard, strings/useStrings split, …) with extraction thresholds. Engines copy patterns *out* of the registry into their own codebases.
+- The Queen Bee Engine is a deployed runtime service at `queenbee.hive.baby` that engines *call into* via `/api/govern`. Engines do not copy QB into themselves.
+
+A pattern in the Substrate Registry can move toward "consumed via QB" rather than "extracted to a package" — for example, the safety-disclaimer pattern is already enforced inside QB's `lib/safety.ts`. Patterns that are ergonomically embedded (strings/useStrings split, operator cookie) will probably stay package-bound; patterns that are ergonomically remote (safety classification, schema validation, language detection) belong in QB.
+
+### When CC works on a Hive engine, the inheritance check
+
+Before scaffolding any of the following into a new engine, check whether QB already provides it:
+
+- Output schema validation (QB has 15 schema types in `lib/schemas.ts`)
+- Safety enforcement (QB has tiered rules in `lib/safety.ts`)
+- Language detection (QB has a Unicode-range heuristic in `lib/grappler.ts`)
+- Compliance audit dashboard for the engine fleet (QB has `/api/audit` and the live page at `queen-bee-v1.vercel.app`)
+- Cross-engine reachability monitoring (QB has `/api/health`)
+
+If QB already has it, add the engine to `queen-bee/lib/registry.ts` and call `/api/govern` instead of re-implementing. If QB doesn't have it, document the gap in this section before building locally — the next engine will face the same question.
+
+---
+
+## VIII. Architecture Decisions and Lessons Learned
 
 This section grows over time and is **never pruned**. Each entry is a
 single paragraph: the incident or insight that motivated a rule.
@@ -808,7 +881,7 @@ classes is a deliberate decision (today: `nextjs`, `static-html`,
 
 ---
 
-## VIII. Update Mechanism  `[GOVERNANCE_LOCATION]`
+## IX. Update Mechanism  `[GOVERNANCE_LOCATION]`
 
 - **Constitution updates require a PR** with the constitution diff.
   No direct-to-main, no exceptions, including for typo fixes.
@@ -824,7 +897,7 @@ classes is a deliberate decision (today: `nextjs`, `static-html`,
   corresponding rule definition in `tools/hive-ops/rules.ts` (H-rules)
   or `tools/hive-finalize/validate.ts` (V-rules). The PR description
   lists which rule was added and why.
-- **Lessons Learned (§VII) grows over time; never prune.** A lesson
+- **Lessons Learned (§VIII) grows over time; never prune.** A lesson
   may be marked superseded with a one-line note explaining what
   replaced it, but the historical incident stays. The point is to
   preserve institutional memory of the *why*, not to keep the


### PR DESCRIPTION
## Summary
- Adds Constitution §VII "Queen Bee Architecture" with anchor `[QUEEN_BEE_LOCATION]`. The section names QB's repo (`saggarsonny-boop/queen-bee`), deployment (`queen-bee-v1.vercel.app`, `queenbee.hive.baby`), built components (Master Grappler + registry + safety + schemas + audit dashboard), and the HTTP-based inheritance mechanism (engines register in `lib/registry.ts` and POST to `/api/govern`).
- Reports the honest adoption gap: as of 2026-05-08 **no engine actually calls `/api/govern` in production** — verified by grep across hivebaby/apps, hivebaby/packages, universal-document/apps, and standalone engine repos. Engines still embed their own safety/schema logic.
- Names what doesn't exist: "Hive Core / Foundry / Factory" and the canonical "27 adoption amplifiers" list don't appear in any repo. Documented as legacy talk pending evidence.
- Distinguishes the Queen Bee Engine (this section) from the existing Queen Bee Substrate Registry in §V — same name, distinct artefacts.
- Renumbers: old §VII (Architecture Decisions and Lessons Learned) → §VIII; old §VIII (Update Mechanism) → §IX. All cross-references updated across `docs/HIVE_CONSTITUTION.md`, `MEMORY.md`, and `CLAUDE.md`.
- Adds MEMORY.md Rule #36 `[QUEEN_BEE_LOCATION]` mirroring §VII so future CC sessions can find QB by anchor name.
- Adds CLAUDE.md B18 — every CC session reads §VII before scaffolding governance functionality into a new engine.

## Discovery evidence (Phase 1+2)
- queen-bee repo: `https://github.com/saggarsonny-boop/queen-bee`, created 2026-04-14, `92KB`, default branch `main`, description "Queen Bee - constitutional governance layer for The Hive".
- Deployed: `queen-bee-v1.vercel.app` returns 200; `queenbee.hive.baby` DNS wired (CNAME to `321cc317b680a981.vercel-dns-017.com`).
- Built (verified by reading the repo): `lib/grappler.ts`, `lib/registry.ts` (14 engines), `lib/safety.ts`, `lib/schemas.ts`, `app/api/{govern,audit,health,registry}/`, `app/page.tsx` audit dashboard, `components/{AutoDemo,FirstVisitCard,TooltipTour}.tsx`.
- Repo CLAUDE.md: `@AGENTS.md` (one line, generic Next.js notes — no QB-specific guidance). This PR establishes the canonical pointer in hivebaby's constitution so the queen-bee repo's empty CLAUDE.md isn't a discoverability hole.

## Phase 4 follow-up
After this PR merges, I'll surface the planned issue list + template for filing "Read §VII before engine work" propagation issues across the live engine repos. No issues filed before that review.

## Test plan
- [ ] CI green (HiveOps audit on docs-only changes)
- [ ] Auto-merge + auto-deploy
- [ ] Phase 4 plan presented; no issues filed without explicit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)