### PR TITLE
docs: HIVE_ARCHITECTURE.md v0.2 — Queen Bee canonized + Foundry/Factory marked legacy talk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 >
 > If a rule here conflicts with an in-conversation instruction, the in-conversation instruction wins for that turn only — durable changes go in the constitution + this file via PR. **Read both files at the start of every session.**
 >
-> **Pan-Hive map:** [`docs/HIVE_ARCHITECTURE.md`](docs/HIVE_ARCHITECTURE.md) is the canonical layer-by-layer view of how Queen Bee → Foundry / Factory → core substrates → engines → public surfaces fit together, with Mermaid diagrams of inheritance, data flow, and module reuse. **Read at the start of any session that touches more than one engine.** `[HIVE_ARCHITECTURE]`
+> **Pan-Hive map (v0.2):** [`docs/HIVE_ARCHITECTURE.md`](docs/HIVE_ARCHITECTURE.md) is the canonical layer-by-layer view of how the Hive fits together. Layer 1 is the **Queen Bee runtime governance engine** at `queenbee.hive.baby` (engines inherit by `POST /api/govern` per `[QUEEN_BEE_LOCATION]` / B18). Layer 2 is intentionally empty — the historical Foundry/Factory framing has been retired as legacy talk. Layer 3 substrates + Layer 4 engines + Layer 5 surfaces follow. Mermaid diagrams of inheritance, data flow, and module reuse. **Read at the start of any session that touches more than one engine.** `[HIVE_ARCHITECTURE]`
 
 ---
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -321,13 +321,13 @@ escalate to a human.
 
 **Title:** The pan-Hive architecture map at `docs/HIVE_ARCHITECTURE.md` is the canonical layer-by-layer view of how the Hive fits together.
 
-**Body:** The architecture doc maps the five-layer stack (Queen Bee → Foundry/Factory → core substrates → engines → public surfaces) with Mermaid diagrams of inheritance, data flow, module reuse, and per-engine substrate adoption. CC reads it at the start of any session that touches more than one engine, and amends it whenever a new engine is scaffolded, a substrate is extracted to a `@hive/*` package, or an adoption amplifier is added.
+**Body:** The architecture doc maps the five-layer stack with Mermaid diagrams of inheritance, data flow, module reuse, and per-engine substrate adoption. CC reads it at the start of any session that touches more than one engine, and amends it whenever a new engine is scaffolded, a substrate is extracted to a `@hive/*` package, or an adoption amplifier is added.
 
-The map distinguishes four kinds of thing — **engines** (own purpose, workflows, public domain, DB, ENGINE_GRAMMAR.md), **modules** (attach via import, no own product surface), **substrates** (registry-tracked patterns, extracted at the 3-engine threshold), and **adoption amplifiers** (HiveOps-enforced cross-cutting features every engine inherits). Conflating these is the most common confusion the doc exists to prevent.
+The map distinguishes four kinds of thing — **engines** (own purpose, workflows, public domain, DB, ENGINE_GRAMMAR.md), **modules** (attach via import, no own product surface), **substrates** (registry-tracked patterns, extracted at the 3-engine threshold), and **adoption amplifiers** (HiveOps-enforced cross-cutting features). Conflating these is the most common confusion the doc exists to prevent.
 
-v0.1 (2026-05-08) captures everything verifiable today; sections marked **AWAITS T1 PR** are placeholders for content T1's Queen Bee discovery PR will land canonically (Layer-1 Queen Bee surface; Tarka / Broomstick / Oompa Loompas in Layer 2; Hive Core / Tone Engine / AI Activity Partner in Layer 3; HiveVitality status; the remaining 2 of the 27 adoption amplifiers).
+v0.2 (2026-05-08) folds in T1's Queen Bee discovery PR (`[QUEEN_BEE_LOCATION]`): Layer 1 is the runtime governance engine at `queenbee.hive.baby`, inherited via `POST /api/govern` (no engine consumes yet — honest gap). Layer 2 is intentionally empty — the historical Foundry / Factory / Tarka / Broomstick / Oompa Loompas framing is retired as legacy talk (no code anywhere as of 2026-05-08). Layer 3 marks Tone Engine / AI Activity Partner / Hive Core as planned-not-built; the formal `ADOPTION_AMPLIFIERS` H-rule category contains just **2 rules** (H24, H25), not 27. HiveVitality: scope defined, build pending Queen Bee consumption pattern from first engine.
 
-**Source:** Locked 2026-05-08. Originated from a request to make the pan-Hive architecture visible from every chat and CC session. v0.1 shipped before T1's Queen Bee PR landed; v0.2 amendment is queued for after T1 merges.
+**Source:** Locked 2026-05-08. Originated from a request to make the pan-Hive architecture visible from every chat and CC session. v0.1 shipped 2026-05-08; v0.2 amendment landed same day after T1's Queen Bee discovery PR (#143).
 
 **Constitution reference:** [§V "Pan-Hive architecture map"](docs/HIVE_CONSTITUTION.md#pan-hive-architecture-map--hive_architecture).
 

--- a/docs/HIVE_ARCHITECTURE.md
+++ b/docs/HIVE_ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Hive Architecture
 
-> **v0.1 — 2026-05-08.** This is the pan-Hive architecture map intended to be visible from every chat, every CC session, every onboarding pass. It exists so a question like *"where does HiveAestheticBestie fit?"* or *"which substrate does this engine inherit?"* has one canonical answer.
+> **v0.2 — 2026-05-08.** This is the pan-Hive architecture map intended to be visible from every chat, every CC session, every onboarding pass. It exists so a question like *"where does HiveAestheticBestie fit?"* or *"which substrate does this engine inherit?"* has one canonical answer.
 >
-> v0.1 captures everything verifiable today. Sections marked **AWAITS T1 PR** are the parts where the Queen Bee discovery work (T1, in flight) will replace placeholders with canonical detail. The rest is anchored to shipped code, the constitution, the substrate registry, and HiveOps verdicts.
+> v0.2 incorporates T1's Queen Bee discovery PR ([Constitution §VII](HIVE_CONSTITUTION.md#vii-queen-bee-architecture--queen_bee_location)). Layer-1 Queen Bee is now canonized (the runtime governance engine at `queenbee.hive.baby`, not a baseline config). The Layer-2 Foundry/Factory framing has been **retired as legacy talk** — those names don't correspond to anything in any repo. Layer-3 Tone Engine / AI Activity Partner / Hive Core are explicitly **planned-not-built**. The "27 adoption amplifiers" framing has been corrected: HiveOps' formal `ADOPTION_AMPLIFIERS` H-rule category currently has just **two** rules (H24, H25); the rest of what v0.1 listed is real-but-uncategorized HiveOps coverage from other rule families. v0.2 changelog at the bottom of this doc.
 
 ## How to read this document
 
@@ -10,14 +10,16 @@ Four kinds of thing live in the Hive. Conflating them is the most common confusi
 
 | Concept | Owns? | Lifespan | Examples |
 |---|---|---|---|
-| **Engine** | Own purpose, workflows, output, public domain, pricing tier, DB schema, `ENGINE_GRAMMAR.md`. | Indefinite, until retired. | UD Converter, ParkBack, HiveAestheticBestie, HiveSecretBox, HiveIMR. |
+| **Engine** | Own purpose, workflows, output, public domain, pricing tier, DB schema, `ENGINE_GRAMMAR.md`. | Indefinite, until retired. | UD Converter, ParkBack, HiveAestheticBestie, HiveSecretBox, HiveIMR, **Queen Bee**. |
 | **Module** | Attaches to an engine via API import or component import. **No own product surface, no own deployment**. Build time hours, not days. | Lives as long as its host engine. | Hive header logo, footer signature, install hint banner, age-band gate, AHTS prompt. |
 | **Substrate** | Registry-tracked pattern extracted when 3+ engines adopt it. May evolve into a shared `@hive/*` package. | Tracked indefinitely; entry becomes a historical pointer when extracted. | Operator role + audit dashboard, `hive_alerts` telemetry, tier-based rate limiting, Stripe tier subscription, 7-language locale generator. |
-| **Adoption amplifier** | Cross-cutting growth/retention feature every engine inherits as part of the Hive integration contract. | Locked to the contract; HiveOps enforces presence. | "Add to home screen" prompt, first-visit explainer, auto-demo, planet placement, footer link row. |
+| **Adoption amplifier** | Cross-cutting growth/retention feature an engine inherits as part of the Hive integration contract. | Locked to the contract; HiveOps enforces presence. | Manifest registration in layout, viewport meta. The broader set is **conceptual** — see Layer 3. |
 
 **Rule of thumb.** If it has a Vercel project, it's an engine. If it's a React component imported by other engines, it's a module. If it's a TypeScript pattern repeated across engine source trees, it's a substrate. If it's a behavior every engine must exhibit (because the contract says so), it's an adoption amplifier.
 
 Engines are the only thing the user directly experiences. The rest is how they're made and held together.
+
+> **Note on Queen Bee.** Queen Bee is **both** a conceptual layer-1 foundation **and** an actual deployed engine (`queen-bee` repo, `queenbee.hive.baby`). Layer 1 of this map is the runtime governance Queen Bee provides; the engine inventory in Layer 4 is where Queen Bee shows up as a Hive engine like any other.
 
 ---
 
@@ -25,85 +27,118 @@ Engines are the only thing the user directly experiences. The rest is how they'r
 
 ```mermaid
 flowchart TD
-  L1["Layer 1 — Foundation\nQueen Bee\n(genetic substrate every engine inherits from)"]
-  L2["Layer 2 — Build Infrastructure\nFoundry (HiveEngineBuilder)\nFactory (Tarka, Broomstick, Oompa Loompas)"]
-  L3["Layer 3 — Core Substrates\nHive Core · Tone Engine · AI Activity Partner\n@hive/onboarding · @hive/auth (planned) · @hive/alerts (planned)\nadoption amplifiers (HiveOps H-rules ADOPTION_AMPLIFIERS family)"]
-  L4["Layer 4 — Engines\nUD Converter · ParkBack · HiveAestheticBestie · HiveIMR\nHivePhoto · HiveSecretBox · HiveBodyLog · HiveField · …\n(see §VI inventory for the full 30+ engine list)"]
-  L5["Layer 5 — Public Surfaces\nhive.baby planet (front door)\nLCARS dashboard (operator view)\n<engine>.hive.baby individual domains"]
+  L1["Layer 1 — Foundation\nQueen Bee runtime governance\nMaster Grappler @ queenbee.hive.baby\nrepo: saggarsonny-boop/queen-bee"]
+  L2["Layer 2 — Build infrastructure\n(historical 'Foundry / Factory / Tarka /\nBroomstick / Oompa Loompas' framing\nis LEGACY TALK — no code anywhere)"]
+  L3["Layer 3 — Core substrates\n@hive/onboarding (live)\n13 substrate patterns in registry\nADOPTION_AMPLIFIERS H-rules (H24, H25)\nplanned: Hive Core · Tone Engine · AIAP"]
+  L4["Layer 4 — Engines\nUD Converter · ParkBack · HiveAestheticBestie · HiveIMR\nHivePhoto · HiveSecretBox · HiveBodyLog · QueenBee · …\n(see §VI inventory for the full 30+ engine list)"]
+  L5["Layer 5 — Public surfaces\nhive.baby planet (front door)\n<engine>.hive.baby individual domains\nqueenbee.hive.baby audit dashboard"]
 
-  L1 -- "genetic substrate;\nshape every engine inherits" --> L2
-  L1 -- "shape" --> L3
-  L1 -- "shape" --> L4
-  L2 -- "scaffolds new engines" --> L4
+  L1 -. "HTTP /api/govern\n(planned consumption pattern;\nno engine consumes yet)" .-> L4
   L3 -- "imported / inlined by every engine" --> L4
   L4 -- "exposed via" --> L5
 
   classDef foundation fill:#D4AF37,stroke:#0a0a0a,color:#0a0a0a,stroke-width:2px
-  classDef build fill:#8a6f1f,stroke:#0a0a0a,color:#f5f1e6,stroke-width:1px
+  classDef legacy fill:#3a3a3a,stroke:#9a9588,color:#9a9588,stroke-width:1px,stroke-dasharray: 4 2
   classDef core fill:#1e2d3d,stroke:#0a0a0a,color:#f5f1e6,stroke-width:1px
   classDef engine fill:#0a0a0a,stroke:#D4AF37,color:#f5f1e6,stroke-width:1px
   classDef surface fill:#f5f1e6,stroke:#0a0a0a,color:#0a0a0a,stroke-width:1px
   class L1 foundation
-  class L2 build
+  class L2 legacy
   class L3 core
   class L4 engine
   class L5 surface
 ```
 
-The five layers are a **vertical inheritance stack**. A change in Layer 1 (Queen Bee) propagates to everything above it. A change in Layer 5 (a single engine's domain configuration) is local. Layers are *not* a deploy pipeline — engines deploy independently — they're a conceptual hierarchy that says *what depends on what*.
+The layers are a **vertical inheritance stack**. Layer 1 (Queen Bee) is the runtime governance an engine *can* inherit by calling its HTTP API. Layer 3 substrates are imported into engine source trees. Layer 5 surfaces are how users reach Layer 4 engines. Layer 2 is rendered greyed-out because the historical Foundry/Factory framing has no correspondence in code today; it is preserved here only so future readers can see the framing was considered and retired.
+
+The Layer-1 → Layer-4 arrow is **dotted** because no engine in production calls `POST /api/govern` yet (per Constitution §VII honest-gap report). Queen Bee is deployed and ready; the inheritance pattern is established but not yet consumed.
 
 ---
 
-## Layer 1 — Queen Bee (foundation)
+## Layer 1 — Queen Bee runtime governance
 
-Queen Bee is the **genetic substrate** of every Hive engine. When CC scaffolds a new engine, the engine inherits Queen Bee's identity rules, design tokens, integration contract, governance hooks, and economic model — these are the things every Hive product has in common. Queen Bee is not a deployable codebase the way an engine is; it's the set of rules and patterns the engine begins life with.
+Queen Bee is the **runtime governance engine** of the Hive ecosystem — the Master Grappler in production. The canonical reference for this layer is [Constitution §VII "Queen Bee Architecture"](HIVE_CONSTITUTION.md#vii-queen-bee-architecture--queen_bee_location); CC's standing rule is `[QUEEN_BEE_LOCATION]` (CLAUDE.md B18): before scaffolding safety enforcement, output schema validation, language detection, compliance audits, or cross-engine reachability monitoring into any new engine, check what Queen Bee already provides and inherit from it.
 
-The canonical Queen Bee surface is the constitution itself: every engine is bound by Constitution §I (identity), §II (engineering standards), §III (pricing model), §IV (workflow conventions), §V (HiveOps governance). HiveOps + HiveFinalize are the automated mechanisms that verify a candidate engine is, in fact, Hive — an engine without these verdicts isn't part of the colony.
+### Where Queen Bee lives
 
-Queen Bee inherits **into** every layer above it.
+| Field | Value |
+|---|---|
+| Repo | [`saggarsonny-boop/queen-bee`](https://github.com/saggarsonny-boop/queen-bee) |
+| Vercel deployment | `queen-bee-v1.vercel.app` |
+| Public domain | `queenbee.hive.baby` |
+| Stack | Next.js 16.2.4 + React 19.2.4 + TypeScript + Anthropic SDK |
+| Status | BUILDING — governance engine in progress (per its `ENGINE_GRAMMAR.md`) |
+| Master Grappler version | `0.2.0` (envelope stamp) |
 
-> **AWAITS T1 PR.** T1 is currently shipping the Queen Bee discovery work as a separate PR adding a §VII section to the constitution that names Queen Bee canonically (vs. the `queen-bee.hive.baby` engine listed in §VI inventory, which is a separate "IN PROGRESS" engine). When that PR lands, this section gets amended to reference the canonical surface. v0.1 captures the conceptual role; the precise mechanism (config file vs. tsconfig template vs. ENGINE_GRAMMAR baseline) is what T1's PR locks in.
+### What's actually built (verified 2026-05-08)
 
----
+| Component | File | Status |
+|---|---|---|
+| Master Grappler | `lib/grappler.ts` | Implemented. Schema field validation, safety check, language detection (zh / ar / ja / ru / en heuristic), QB envelope stamping. |
+| Engine registry | `lib/registry.ts` | **14 engines** registered with `id, name, domain, status, tone, safety, schema, multilingual, description`. |
+| Safety enforcement | `lib/safety.ts` | Tiered rules: universal blocks (suicide/self-harm, weapons synthesis, CSAM); standard blocks; medical-flag patterns; elevated-flag patterns; per-tier disclaimer requirements. |
+| Output schemas | `lib/schemas.ts` | Required-field map for **15 schema types** (`time-response`, `clarity-response`, `scenario-response`, `coaching-response`, `health-log-response`, `governance-response`, `moon-response`, `lookup-response`, `builder-response`, `conversion-response`, `reader-response`, `creator-response`, `validator-response`, `secret-response`, `generic`). |
+| Public API | `app/api/` | `POST /api/govern` (validate + stamp), `GET /api/registry`, `GET /api/audit` (dashboard data), `GET /api/health` (live engine reachability). |
+| Audit dashboard | `app/page.tsx` | Live UI at `queen-bee-v1.vercel.app` rendering reachability + governed-flag for every registered engine. |
+| Onboarding stack | `components/{AutoDemo,FirstVisitCard,TooltipTour}.tsx` | Implemented in the QB engine itself. |
 
-## Layer 2 — Foundry + Factory (build infrastructure)
-
-Tooling that builds engines, not engines themselves.
-
-### Foundry — `HiveEngineBuilder` (`hiveenginebuilder.hive.baby`)
-
-The builder UI. Operator-facing. Takes an engine sketch (purpose, inputs, outputs, pricing tier) and emits a scaffolded engine repo with `ENGINE_GRAMMAR.md`, the canonical onboarding stack, the favicon set, the manifest, the locale catalog, and the Vercel + Cloudflare wiring. Status: **LIVE**. Per CLAUDE.md D inventory.
-
-The Foundry is the entry point Sonny uses when the conversation reaches "let's build a new engine for X." A new engine is built by sketching it in the Foundry and letting the Foundry emit a scaffold; CC then fills in the engine-specific logic. The Foundry uses Anthropic for the inference layer.
-
-### Factory — Tarka, Broomstick, Oompa Loompas
-
-> **AWAITS T1 PR.** v0.1 names the three Factory roles per the user's brief but does not yet have canonical documentation for them. T1's Queen Bee PR is expected to fix the names, scopes, and codebases. v0.1 placeholder:
->
-> - **Tarka** — heavy-duty engine builder agent. Used when an engine needs more than a Foundry scaffold (custom integrations, novel UI surfaces, multi-engine workflows).
-> - **Broomstick** — sweep / cleanup agent. Used for migrations, audit remediations, bulk renames across the colony.
-> - **Oompa Loompas** — task-runner swarm. Used when a job parallelizes well across many engines (e.g. running HiveOps against every engine, generating locale catalogs across the fleet).
->
-> When T1's PR lands, replace the descriptions with the canonical scope, the agent invocation surface, and the file paths.
+### Inheritance mechanism — HTTP, not a package
 
 ```mermaid
-flowchart LR
-  F["Foundry\n(HiveEngineBuilder)\nhiveenginebuilder.hive.baby"]
-  T["Tarka\n(custom engine builder)\nAWAITS T1 PR"]
-  B["Broomstick\n(sweep/cleanup)\nAWAITS T1 PR"]
-  O["Oompa Loompas\n(task-runner swarm)\nAWAITS T1 PR"]
-  E["Engine repo\n(apps/<slug>/ or external repo)"]
+sequenceDiagram
+  autonumber
+  participant Engine as Engine route handler\n(any Hive engine)
+  participant QB as Queen Bee\nqueenbee.hive.baby/api/govern
+  participant Client as Engine client surface
 
-  F -- "scaffold from sketch" --> E
-  T -- "build custom logic" --> E
-  B -- "migrate / remediate" --> E
-  O -- "fan out across all engines" --> E
-
-  classDef tool fill:#8a6f1f,stroke:#0a0a0a,color:#f5f1e6
-  classDef out fill:#0a0a0a,stroke:#D4AF37,color:#f5f1e6
-  class F,T,B,O tool
-  class E out
+  Engine->>QB: POST /api/govern\n{ engineId, input, content }
+  alt valid
+    QB-->>Engine: 200 + stamped envelope\n{ safe, governed, language,\n  flags, version, timestamp }
+    Engine-->>Client: pass envelope through unchanged
+  else invalid
+    QB-->>Engine: 422 + failure report\n{ errors[] }
+    Engine-->>Client: 4xx + reason
+  end
 ```
+
+An engine inherits from QB by:
+
+1. **Registering** in `queen-bee/lib/registry.ts` with `{id, name, domain, status, tone, safety, schema, multilingual, description}`. The slug becomes the `engineId` it sends to the Grappler.
+2. **Calling** `POST https://queenbee.hive.baby/api/govern` with `{engineId, input, content}` before returning each output.
+3. **Returning the envelope** to the client unchanged — it carries `safe`, `governed`, `language`, `flags`, `version`, `timestamp` fields the client surface can render.
+
+There is no shared library yet. A future `@hive/grappler-client` package becomes plausible once two or more engines are calling `/api/govern` in production.
+
+### Honest gap — adoption status
+
+As of 2026-05-08, **no Hive engine in any monorepo or standalone repo actually calls `/api/govern` in production**. Verified by `grep -r "queenbee\.|api/govern|queen-bee-v1" --include="*.ts" --include="*.tsx"` across `hivebaby/apps/`, `hivebaby/packages/`, `universal-document/apps/`, and the standalone engine repos.
+
+The 14 engines in `queen-bee/lib/registry.ts` are *registered* (so QB knows about them and can audit their reachability) but not *governed* (they don't route their outputs through QB). The audit dashboard's `governed: true` is a reachability check, not proof the engine called QB.
+
+Queen Bee is deployed and ready; the inheritance pattern is established in code but not yet consumed. The first engine to wire `/api/govern` is also documenting the wiring pattern for the next.
+
+### Relationship to §V Substrate Registry
+
+The [Substrate Registry (`docs/QUEEN_BEE_SUBSTRATES.md`)](QUEEN_BEE_SUBSTRATES.md) and the Queen Bee runtime engine are **distinct artefacts that share a name**:
+
+- The Substrate Registry is a markdown ledger listing 13 reusable code patterns. Engines copy patterns *out* of the registry into their codebases.
+- The Queen Bee Engine is a deployed runtime service. Engines *call into* it via HTTP.
+
+A pattern in the registry can move toward "consumed via QB" rather than "extracted to a package" — for example, the safety-disclaimer pattern is already enforced inside QB's `lib/safety.ts`. Patterns that are ergonomically embedded (strings/useStrings split, operator cookie) will probably stay package-bound; patterns that are ergonomically remote (safety classification, schema validation, language detection) belong in QB.
+
+---
+
+## Layer 2 — Build infrastructure (legacy talk; retired)
+
+Earlier conversations referred to a **Foundry** (a builder UI) and a **Factory** (Tarka, Broomstick, Oompa Loompas) at this layer. Per [Constitution §VII](HIVE_CONSTITUTION.md#things-described-elsewhere-that-dont-exist-yet), **none of these names corresponds to anything in any repo as of 2026-05-08**:
+
+- No code, no docs, no anchors in `hivebaby`, `queen-bee`, `universal-document`, or any engine repo for "Foundry", "Tarka", "Broomstick", "Oompa Loompas", or "Hive Core".
+- If they were ever shipped, they've since been deleted or renamed; no commit history surfaces them.
+- The runtime governance role those names were probably reaching for is now the Master Grappler in the queen-bee repo (Layer 1, above).
+
+`HiveEngineBuilder` (`hiveenginebuilder.hive.baby`) exists and is LIVE, but it's a **deployed engine** in Layer 4 — not a special "Foundry" tier. v0.1 of this map placed HiveEngineBuilder in Layer 2 as the Foundry; v0.2 moves it into Layer 4 with the rest of the engines.
+
+> **Treat references to Foundry / Factory / Tarka / Broomstick / Oompa Loompas as legacy talk pending evidence to the contrary.** If a future PR introduces real codebases under these names, this section gets rewritten with the canonical scope and file paths. Until then, this layer is intentionally empty.
 
 ---
 
@@ -111,68 +146,48 @@ flowchart LR
 
 Things that live across engines without being engines themselves.
 
-### Core packages (`@hive/*` and inlined siblings)
+### Core packages — shipped + planned
 
 | Package | Status | What it is |
 |---|---|---|
-| `@hive/onboarding` (`packages/hive-onboarding/`) | live (v0.1) | The PWA install hint, first-visit explainer, AHTS prompt, install toast, 7-locale catalog. Canonical source for the install + onboarding behavior every engine ships. |
-| `@hive/auth` | **planned** | Operator role + audit dashboard. 2 engines using the pattern today (UD Converter, HiveActivityPartner-retracted); HivePhoto is queued. Substrate registry entry [pattern 1 + 2]. |
-| `@hive/alerts` | **planned** | `hive_alerts` ledger emitter. 4+ engines write today. Substrate registry entry [pattern 11]. |
-| `@hive/rate-limit` | **planned** | Tier-based rate limiter. 3 engines today. Substrate registry entry [pattern 12]. |
-| `@hive/stripe-tiers` | **planned** | Plus / Pro tier checkout + webhook + signed cookie verification. Substrate registry entry [pattern 13]. |
-| `@hive/i18n-generate` (tool, hivebaby-resident) | **planned** | Anthropic-Haiku-driven 7-language translator. Every engine uses it; today it's duplicated. Substrate registry entry [pattern 7]. |
+| `@hive/onboarding` (`packages/hive-onboarding/`) | **live (v0.1)** | The PWA install hint, first-visit explainer, AHTS prompt, install toast, 7-locale catalog. Canonical source for the install + onboarding behavior every engine ships. |
+| `@hive/auth` | **planned** (substrate registry [1+2]) | Operator role + audit dashboard. 2 engines using the pattern today. |
+| `@hive/alerts` | **planned** (substrate registry [11]) | `hive_alerts` ledger emitter. 4+ engines write today. |
+| `@hive/rate-limit` | **planned** (substrate registry [12]) | Tier-based rate limiter. 3 engines today. |
+| `@hive/stripe-tiers` | **planned** (substrate registry [13]) | Plus / Pro tier checkout + webhook + signed cookie verification. |
+| `@hive/i18n-generate` (tool, hivebaby-resident) | **planned** (substrate registry [7]) | Anthropic-Haiku-driven 7-language translator. Every engine uses it; today it's duplicated. |
+| `@hive/grappler-client` | **plausible** | HTTP client for `POST /api/govern`. Becomes worth building once 2+ engines call QB. |
 
-The full 13 substrate patterns currently in flight are tracked in [`docs/QUEEN_BEE_SUBSTRATES.md`](QUEEN_BEE_SUBSTRATES.md). When a substrate crosses the 3-engine threshold, it's extracted into a real package and graduates from the substrate registry into this list.
+The 13 substrate patterns currently in flight are tracked in [`docs/QUEEN_BEE_SUBSTRATES.md`](QUEEN_BEE_SUBSTRATES.md). When a substrate crosses the 3-engine threshold, it's extracted into a real package and graduates from the registry into this list.
 
-### Hive Core, Tone Engine, AI Activity Partner
+### Tone Engine, AI Activity Partner, Hive Core — planned, not yet built
 
-> **AWAITS T1 PR.** The user's brief named these three as Layer-3 components, but their canonical codebases / responsibilities aren't fully captured in current docs. v0.1 placeholder per the user's framing:
->
-> - **Hive Core** — the cross-engine substrate that every engine inherits the integration contract from. Likely overlaps with the `@hive/*` package set + the constitution. T1's PR is expected to draw the line between Queen Bee (Layer 1, identity/governance) and Hive Core (Layer 3, runtime substrate).
-> - **Tone Engine** — the writing-voice consistency layer. Ensures user-facing copy across engines reads as the same product family. May be a service, a prompt template set, or a CLI lint.
-> - **AI Activity Partner** — the conversational companion module. Distinct from the retracted `hive-activity-partner` engine; this is the cross-engine companion surface, e.g. a guidance chat that floats over any engine.
->
-> When T1's PR lands, replace these three placeholders with canonical scope + file paths.
+Earlier conversations placed Tone Engine, AI Activity Partner (AIAP), and Hive Core at this layer. **None of them exists in any repo today** (verified per Constitution §VII honest-gap report).
 
-### Adoption amplifiers
-
-The cross-cutting growth/retention features every engine must exhibit. Enforced by HiveOps H-rules under the `ADOPTION_AMPLIFIERS` category (per CLAUDE.md §E3). The full list of H-rules is in `tools/hive-ops/README.md`; the subset that count as adoption amplifiers in v0.1 are:
-
-| # | Amplifier | Where it shows up |
+| Concept | Status | What it would be |
 |---|---|---|
-| 1 | Hive header logo | Top of every page; clickable link to `https://hive.baby` |
-| 2 | Hive footer signature ("Made with ♥ in the Hive") | Bottom of every page |
-| 3 | Hive footer link row (`hive.baby · social experiment · contribute · patronage · privacy`) | Bottom of every page |
-| 4 | Add-to-home-screen prompt (`<HiveAHTSPrompt />`) | After first successful primary action |
-| 5 | First-visit explainer (`<HiveFirstVisitExplainer />`) | Under the primary CTA, dismissed on first action |
-| 6 | Install hint banner (`<HiveInstallHint />`) | Platform-specific (Chrome programmatic, iOS guided) |
-| 7 | App-installed toast (`<AppInstalledToast />`) | Engine-local layout toast |
-| 8 | Auto-demo script (engines with chat surfaces) | Typewriter on first visit, fades after 8s |
-| 9 | Planet placement | Engine appears on `hive.baby` planet as a hex cell |
-| 10 | Patronage cell linkage | Voluntary support routed via planet's amber/copper cell |
-| 11 | 7-language locale set (`en, es, fr, ar, hi, zh, pt`) | Free-tier floor for every engine |
-| 12 | "No ads. No investors. No agenda." page footer | Brand promise on every engine |
-| 13 | "Add to home screen" copy (gentle, never "Install") | Platform install prompts |
-| 14 | Health endpoint (`/api/health`) | Operational visibility / monitoring |
-| 15 | Hive gold (`#D4AF37`) on primary CTAs | Visual consistency across the colony |
-| 16 | Theme color = Hive gold (`metadata.themeColor` + `manifest.theme_color`) | Address-bar tint |
-| 17 | Apple web-app meta (`appleWebApp = {capable: true, statusBarStyle: "black-translucent"}`) | iOS standalone behavior |
-| 18 | Manifest complete (`name, short_name, description, theme_color, background_color, display, start_url, scope, id, icons`) | PWA installability |
-| 19 | Favicon complete set (16, 32, 180, 192, 512, maskable) | Cross-platform install icon |
-| 20 | Tab title descriptive (`<EngineName> — <tagline>`) | Browser tab + bookmarks legibility |
-| 21 | Plain-language user-voice phrasing | Anti-jargon contract |
-| 22 | Production copy hygiene (no "coming soon" / "TODO") | Anti bait-and-switch |
-| 23 | Cite-real-sources for third-party data | No fabrication |
-| 24 | `ENGINE_GRAMMAR.md` present + valid frontmatter | Machine-readable engine identity |
-| 25 | Engine entry in `hivebaby` planet `ENGINES` array | Discoverability via the planet |
+| Tone Engine | **planned, not yet built** | Writing-voice consistency layer; ensures user-facing copy reads as the same product family. May land as a prompt-template set, a CLI lint, or a QB module. Waiting on the first consuming engine to validate the pattern. |
+| AI Activity Partner | **planned, not yet built** | Cross-engine conversational companion module. **Distinct from the retracted `hive-activity-partner` engine** — that was a product, this would be infrastructure (a guidance chat that floats over any engine). Waiting on the first consuming engine. |
+| Hive Core | **planned, not yet built** | The cross-engine substrate for the integration contract. Likely overlaps with the `@hive/*` package set. Waiting on consolidation pattern from QB consumers. |
 
-> **AWAITS T1 PR.** The user's brief named **27 adoption amplifiers**. v0.1 captures 25 anchored to the H-rules visible in CLAUDE.md §E3 + Constitution §V. The other two are likely Tone-Engine-related and/or AI-Activity-Partner-related and will land with T1's PR. When T1 lands, this list is updated to 27 with canonical names and the H-rule that enforces each.
+The pattern is the same in every case: build it when an engine actually needs it, not as speculative infrastructure. The first engine to call `/api/govern` will probably also be the first engine that surfaces what Tone Engine and AIAP need to be.
+
+### Adoption amplifiers — the honest count
+
+The HiveOps `ADOPTION_AMPLIFIERS` H-rule category formally contains **two rules** today:
+
+- **H24** — manifest registration in layout (the engine actually mounts `manifest.json` via `<link rel="manifest" />`).
+- **H25** — viewport meta correctly set for mobile installability.
+
+That's the canonical list. Earlier framings of "27 adoption amplifiers" were aspirational — no canonical list of 27 exists in any repo on 2026-05-08, and v0.1 of this map enumerated 25 items that mostly belong to OTHER H-rule categories (HIVE_INTEGRATION for the header logo + footer signature, DESIGN_CONSISTENCY for the Hive gold + theme color, OPERATIONAL for the health endpoint, INTERNATIONALIZATION for the 7-locale set, etc.). Those rules are real and enforced — they just aren't `ADOPTION_AMPLIFIERS`.
+
+**For the actual list of HiveOps rules, see `tools/hive-ops/README.md` and Constitution §V.** Future PRs that introduce a true 27-amplifier curation should link this section, and v0.3 of this doc can update the count from canonical source.
 
 ---
 
 ## Layer 4 — Engines (the things users actually use)
 
-Every engine listed in CLAUDE.md §D + Constitution §VI inventory. Status as of 2026-05-06 sweep + 2026-05-08 migrations.
+Every engine listed in CLAUDE.md §D + Constitution §VI inventory. Status as of 2026-05-06 sweep + 2026-05-08/09 migrations.
 
 ### Hivebaby-resident engines (audited by HiveOps)
 
@@ -183,6 +198,7 @@ Every engine listed in CLAUDE.md §D + Constitution §VI inventory. Status as of
 | HiveAestheticBestie | `hive-aestheticbestie` | hiveaestheticbestie.hive.baby | LIVE | ✅ PASS |
 | HivePhoto | `hive-hivephoto` | hivephoto.hive.baby | LIVE | ✅ PASS |
 | HiveIMR | `hive-imr` | hiveimr.hive.baby | LIVE | ✅ PASS |
+| HiveSecretBox | `secret-box` | secretbox.hive.baby | LIVE | ✅ PASS (canonical migration #5, 2026-05-09) |
 | HivePlainScan | `hive-plainscan` | plainscan.hive.baby | DORMANT (no DNS, no demand) | ⚠️ WARN (overrides expire 2026-06-05) |
 
 ### Hivebaby-resident, separate nested git repo
@@ -201,10 +217,9 @@ Every engine listed in CLAUDE.md §D + Constitution §VI inventory. Status as of
 | HiveClarity | hiveclarity.hive.baby | LIVE | Anthropic |
 | HiveStrength | hivestrength.hive.baby | LIVE | Anthropic |
 | HiveBodyLog | hivebodylog.hive.baby | LIVE | Anthropic |
-| HiveEngineBuilder | hiveenginebuilder.hive.baby | LIVE | The Foundry. Anthropic. |
-| QueenBee | queenbee.hive.baby | IN PROGRESS | Engine-form of the foundation; distinct from the conceptual Queen Bee in Layer 1 |
+| HiveEngineBuilder | hiveenginebuilder.hive.baby | LIVE | Engine builder UI. **Was placed in Layer 2 in v0.1; moved to Layer 4 in v0.2** (the "Foundry" framing was retired). |
+| QueenBee | queenbee.hive.baby | BUILDING | The runtime governance engine; see Layer 1 for canonical detail. |
 | HiveCreatorConsole | creatorconsole.hive.baby | LIVE | |
-| HiveSecretBox | secretbox.hive.baby | LIVE | T3 cost-cap circuit breaker in flight |
 | WhoTextedMe | whotextedme.hive.baby | LIVE | Anthropic |
 | HiveAdminSupport | support.hive.baby | LIVE | Reads `hive_alerts`; routes inbound emails |
 | HiveMeme | hivememe.hive.baby | BUILDING | Anthropic |
@@ -226,7 +241,7 @@ Every engine listed in CLAUDE.md §D + Constitution §VI inventory. Status as of
 
 ### HiveVitality
 
-> **AWAITS T1 PR.** The user's brief mentioned HiveVitality as an engine. It does not appear in the current Constitution §VI inventory or CLAUDE.md D inventory. v0.1 records the name; T1's PR will determine whether HiveVitality is a planned engine, an in-flight engine, or a renaming of an existing engine. Until then, treat as **NOT YET INVENTORIED**.
+**Scope defined; build pending Queen Bee consumption pattern from first engine.** HiveVitality does not appear in the Constitution §VI inventory, CLAUDE.md D inventory, or any repo on 2026-05-08. It will land once one of the existing engines (most plausibly HiveBodyLog or HivePhoto) demonstrates the QB consumption pattern end-to-end and that pattern can be reproduced for a vitality-specific surface.
 
 ---
 
@@ -247,6 +262,10 @@ flowchart LR
     S11["[11] hive_alerts telemetry"]
     S12["[12] Tier rate-limit"]
     S13["[13] Stripe tier subscription"]
+  end
+
+  subgraph QB["Layer 1 — Queen Bee"]
+    QBAPI["POST /api/govern\nqueenbee.hive.baby"]
   end
 
   subgraph ENGINES["Layer 4 engines"]
@@ -298,21 +317,27 @@ flowchart LR
   S13 --> UDC
   S13 --> HP
 
+  QBAPI -.no engine consumes yet.-> UDC
+  QBAPI -.no engine consumes yet.-> HP
+  QBAPI -.no engine consumes yet.-> HSB
+
   classDef sub fill:#1e2d3d,stroke:#0a0a0a,color:#f5f1e6
   classDef live fill:#0a0a0a,stroke:#D4AF37,color:#f5f1e6
   classDef retracted fill:#0a0a0a,stroke:#8a6f1f,color:#9a9588,stroke-dasharray: 4 2
+  classDef qb fill:#D4AF37,stroke:#0a0a0a,color:#0a0a0a
   class S1,S3,S4,S5,S6,S7,S9,S11,S12,S13 sub
   class UDC,HP,HSB,PB,HIMR,HAB,HAS live
   class HAP retracted
+  class QBAPI qb
 ```
 
-> The full adoption table is in [`docs/QUEEN_BEE_SUBSTRATES.md`](QUEEN_BEE_SUBSTRATES.md) under "Substrate Adoption Tracker." This diagram visualizes the same data — substrates are extracted to `@hive/*` packages when a column hits 3+ live engines.
+> The full adoption table is in [`docs/QUEEN_BEE_SUBSTRATES.md`](QUEEN_BEE_SUBSTRATES.md) under "Substrate Adoption Tracker." This diagram visualizes the same data — substrates are extracted to `@hive/*` packages when a column hits 3+ live engines. The Queen Bee `/api/govern` arrows are dotted because no engine consumes the API yet (Constitution §VII honest-gap report).
 
 ---
 
 ## Data flow — a user request through the layers
 
-How a request from a user's browser ends up writing a row to a `hive_alerts` ledger and resolving back to a rendered response.
+How a request from a user's browser flows through DNS → edge → route handler → substrates → optionally Queen Bee → DB / Anthropic, and back to the client.
 
 ```mermaid
 sequenceDiagram
@@ -322,6 +347,7 @@ sequenceDiagram
   participant V as Vercel edge\n(deployed engine)
   participant N as Next.js route handler\n(engine app/api/*)
   participant SS as Layer 3 substrates\n(operator auth, rate-limit,\nvalidation, safety)
+  participant QB as Queen Bee\nqueenbee.hive.baby/api/govern\n(NOT YET CONSUMED)
   participant DB as Neon Postgres\n(engine + hive_alerts)
   participant A as Anthropic API\n(Opus / Haiku)
   participant HA as HiveAdminSupport\n(reader of hive_alerts)
@@ -335,6 +361,7 @@ sequenceDiagram
     N->>DB: SELECT engine state
     N->>A: Anthropic call (if engine uses LLM)
     A-->>N: response
+    Note over N,QB: Future: N->>QB POST /api/govern\nQB-->>N stamped envelope
     N->>DB: INSERT engine row
     N->>DB: best-effort INSERT into hive_alerts (tier 1-3)
     N-->>U: 200 + JSON / HTML
@@ -346,7 +373,7 @@ sequenceDiagram
   HA->>HA: tier-3 → page Sonny\ntier-2 → AdminSupport dashboard
 ```
 
-The edge → route handler → substrate stack → DB / Anthropic shape is the **same on every engine**. What varies is which substrates it composes.
+The edge → route handler → substrate stack → DB / Anthropic shape is the **same on every engine**. What varies is which substrates it composes. The QB hop is **not yet wired in any engine** — it's drawn here as a `Note over` so the diagram shows where it would land when the first engine adopts the pattern.
 
 ---
 
@@ -401,52 +428,46 @@ Modules 1–7 ship in `@hive/onboarding`. Engines either consume the workspace p
 |---|---|---|
 | **The planet** | `https://hive.baby` | The front door. Three.js scene with hex cells, one per engine. Live engines glow `#D4AF37`; "coming soon" cells are faded grey; the patronage cell is amber/copper. |
 | **Individual engine domains** | `<engine>.hive.baby` | Each engine's own UI surface, accessed directly by URL or via planet fly-through. |
-| **LCARS dashboard** | (operator-only, route TBD) | Internal operations view. Aggregates HiveOps verdicts, `hive_alerts` tier-2 events, billing reconciliation, deploy hooks. |
+| **Queen Bee audit dashboard** | `https://queenbee.hive.baby` | Live UI rendering reachability + governed-flag for every registered engine (read from `/api/audit`). |
 | **Patrons page** | `https://hive.baby/patrons.html` | Voluntary support surface. Linked from the planet's amber/copper cell. |
 
 The planet is **the only Hive surface a casual visitor sees**. Every engine listing in §VI has an entry in the planet's `ENGINES` array (HiveOps H21). Patronage is the only commercial surface on the planet itself — engine paid tiers live on each engine's own domain.
 
 ---
 
-## What's in v0.1, what awaits T1's Queen Bee PR
+## Changelog
 
-### Captured precisely in v0.1
-- Conceptual model (engine vs module vs substrate vs amplifier).
-- Five-layer stack with inheritance arrows.
-- Per-engine inheritance map (drawn from the substrate registry adoption tracker).
-- Data flow sequence diagram.
-- Module reuse diagram.
-- Engine inventory + HiveOps verdicts (anchored to Constitution §VI as of 2026-05-06 sweep + 2026-05-08 migrations).
-- 25 of the 27 adoption amplifiers (anchored to HiveOps H-rules ADOPTION_AMPLIFIERS family + Constitution §II `[FOOTER_SIGNATURE]` / `[PWA_STANDARDS]`).
+### v0.2 — 2026-05-08
 
-### Awaits T1's Queen Bee PR
-- **Layer 1**: canonical Queen Bee surface (config file vs. tsconfig template vs. ENGINE_GRAMMAR baseline). Today's section captures the conceptual role.
-- **Layer 2**: Tarka, Broomstick, Oompa Loompas — canonical scope, agent invocation, file paths.
-- **Layer 3**: Hive Core, Tone Engine, AI Activity Partner — canonical scope, file paths, and how they relate to the planned `@hive/*` packages.
-- **Layer 4**: HiveVitality status (planned / in-flight / renaming).
-- The remaining 2 of the 27 adoption amplifiers (likely Tone-Engine + AI-Activity-Partner-related).
+- Queen Bee canonical surface added per [Constitution §VII](HIVE_CONSTITUTION.md#vii-queen-bee-architecture--queen_bee_location): repo `saggarsonny-boop/queen-bee`, deployed at `queenbee.hive.baby`, runtime governance via `POST /api/govern` (HTTP not config; no engine consumes yet).
+- Foundry / Factory / Tarka / Broomstick / Oompa Loompas marked as **legacy talk pending evidence** — no code anywhere in the colony as of 2026-05-08.
+- AI Activity Partner / Tone Engine / Hive Core marked as **planned-not-built**. Each waits on the first consuming engine to validate the pattern.
+- HiveVitality: **scope defined, build pending Queen Bee consumption pattern from first engine**.
+- Adoption amplifier count corrected: HiveOps `ADOPTION_AMPLIFIERS` rule category currently has just **2 rules** (H24, H25). The previous v0.1 list of 25 mostly corresponded to other H-rule categories (HIVE_INTEGRATION, DESIGN_CONSISTENCY, OPERATIONAL, INTERNATIONALIZATION) and was misplaced.
+- HiveEngineBuilder moved from Layer 2 (Foundry) to Layer 4 (just an engine).
+- HiveSecretBox audit verdict updated to ✅ PASS (canonical migration #5, 2026-05-09).
+- Five-layer Mermaid diagram: Layer 2 rendered greyed-out + dashed; Layer 1 → Layer 4 dotted (consumption gap).
+- Per-engine inheritance map: added Queen Bee `/api/govern` node with dotted lines to candidate engines.
+- Data-flow sequence: added `Note over` for the future QB hop.
+- Re-cast Queen Bee section to point CC at CLAUDE.md `B18` / `[QUEEN_BEE_LOCATION]` standing rule.
 
-### How v0.2 lands
-T1's Queen Bee PR (saggarsonny-boop/hivebaby/pulls — search for `queen bee`) is expected to add a §VII section to the constitution that names Queen Bee canonically. When that PR merges:
+### v0.1 — 2026-05-08
 
-1. Re-read the new §VII section.
-2. Replace each **AWAITS T1 PR** placeholder in this doc with the canonical content.
-3. Update the v0.1 marker at the top to v0.2 with a dated changelog row.
-4. Bump the constitution reference at the bottom.
-
-This document is meant to be amended every time a substrate hits the 3-engine threshold and is extracted, every time a new engine is scaffolded, and every time a new adoption amplifier is added to the H-rules. It is a living map, not a one-shot scaffold.
+- Initial map. Five-layer stack, conceptual model, Mermaid diagrams (5-layer, Foundry/Factory detail, per-engine substrate map, request data flow, module reuse), engine inventory + HiveOps verdicts, 25-of-27 adoption amplifiers list (anchored to H-rules then known).
+- Sections marked **AWAITS T1 PR** for content T1's Queen Bee discovery PR was expected to land canonically. v0.2 above resolves all of those.
 
 ---
 
 ## Pointers
 
+- **Queen Bee runtime governance:** [Constitution §VII](HIVE_CONSTITUTION.md#vii-queen-bee-architecture--queen_bee_location) · CLAUDE.md `B18` · `[QUEEN_BEE_LOCATION]` · `https://github.com/saggarsonny-boop/queen-bee` · `queenbee.hive.baby`
 - **Engines:** Constitution §VI · CLAUDE.md §D · `engines.json`
 - **Substrates:** [`docs/QUEEN_BEE_SUBSTRATES.md`](QUEEN_BEE_SUBSTRATES.md)
-- **Adoption amplifiers (enforced):** `tools/hive-ops/README.md` (H-rules) · Constitution §V `[HIVEOPS_v01]`
+- **HiveOps rules (the actual list):** `tools/hive-ops/README.md` · Constitution §V `[HIVEOPS_v01]`
 - **Modules (`@hive/onboarding`):** `packages/hive-onboarding/`
 - **Governance:** [`docs/HIVE_CONSTITUTION.md`](HIVE_CONSTITUTION.md) · [`MEMORY.md`](../MEMORY.md) · [`CLAUDE.md`](../CLAUDE.md)
 - **Engine launch checklist:** [`docs/HIVE_ENGINE_FINALIZATION_CHECKLIST.md`](HIVE_ENGINE_FINALIZATION_CHECKLIST.md)
 
 ---
 
-*Maintained by Sonny. PR-only updates per `[GOVERNANCE_LOCATION]`. v0.1 — 2026-05-08.*
+*Maintained by Sonny. PR-only updates per `[GOVERNANCE_LOCATION]`. v0.2 — 2026-05-08.*


### PR DESCRIPTION
## Summary

Folds T1's Queen Bee discovery PR (#143 → Constitution §VII) into the pan-Hive architecture map. Resolves every `AWAITS T1 PR` placeholder from v0.1, corrects the adoption-amplifier count, and retires the Foundry/Factory framing.

## What changed by layer

**Layer 1 — Queen Bee canonized.**
- Repo: `saggarsonny-boop/queen-bee` · deployment: `queen-bee-v1.vercel.app` · domain: `queenbee.hive.baby`.
- Master Grappler (`lib/grappler.ts`), engine registry of 14 engines (`lib/registry.ts`), tiered safety, 15 schema types, audit dashboard.
- Inheritance is HTTP, not config: engines `POST /api/govern` to get a stamped envelope.
- **Honest gap:** no engine consumes `/api/govern` in production yet (per §VII). Layer-1 → Layer-4 arrow drawn dotted.

**Layer 2 — retired.**
- Foundry / Factory / Tarka / Broomstick / Oompa Loompas have **no code anywhere** as of 2026-05-08 (per §VII honest-gap report). Rendered greyed-out + dashed in the 5-layer Mermaid; v0.1's detailed Foundry/Factory diagram removed.
- HiveEngineBuilder moved from Layer 2 → Layer 4 (just an engine).

**Layer 3 — corrections.**
- Tone Engine, AI Activity Partner, Hive Core marked **planned-not-built**. Each waits on first consuming engine.
- Adoption amplifier count corrected: `ADOPTION_AMPLIFIERS` H-rule category has **2 rules** (H24, H25), not 27. v0.1's enumeration of 25 was real-but-uncategorized HiveOps coverage from other rule families and was misplaced.
- `@hive/grappler-client` added as a plausible package once 2+ engines consume QB.

**Layer 4.**
- HiveVitality: **scope defined, build pending Queen Bee consumption pattern from first engine**.
- HiveSecretBox audit: ✅ PASS (canonical migration #5, 2026-05-09).
- HiveActivityPartner marked as Phase-1 retracted/redesigning.

**Diagrams.**
- Per-engine inheritance map: added QB `/api/govern` node with dotted "no engine consumes yet" arrows.
- Data-flow sequence: added `Note over` for the future QB hop.

## Governance updates

- `CLAUDE.md` preamble updated to reflect v0.2 + B18 / `[QUEEN_BEE_LOCATION]`.
- `MEMORY.md` Rule #36 body rewritten to reflect v0.2 reality.
- Sync check verified locally: `PASS, all 24 memory tags reflected` (24 = previous 23 + `[QUEEN_BEE_LOCATION]` from T1's PR #143).

## Test plan

- [ ] `memory-constitution-sync` CI green
- [ ] Auto-merge per B1
- [ ] Re-read after the first engine actually wires `/api/govern` and bump to v0.3 with the wiring pattern documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)