### PR TITLE
feat(hive-plainscan,docs): OpenAI gpt-image-1 for medical illustrations + amend C10 AI provider routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,10 +168,13 @@ All user-facing button labels and headings must use plain-language user-voice ph
 - Analytics: Plausible cloud, Umami self-hosted, or homemade Neon counter.
 
 ### C10. Standard new engine pattern
-- Next.js + TypeScript, Anthropic SDK (`claude-opus-4-5` for primary models; `claude-haiku-4-5-20251001` for safety scans / classification).
+- Next.js + TypeScript.
+- **AI provider routing** `[AI_PROVIDER_ROUTING]`:
+  - **Text generation, classification, summarization, reasoning** → Anthropic SDK (`claude-opus-4-5` for primary models; `claude-haiku-4-5-20251001` for safety scans / classification). Default in every engine; `ANTHROPIC_API_KEY` in Vercel env vars (Production scope).
+  - **Image generation** → OpenAI `gpt-image-1` via the OpenAI SDK. **Canonical exception** until Anthropic ships raster image generation, at which point the fleet migrates. `OPENAI_API_KEY` in Vercel env vars per engine that needs imaging. Engineering rationale: as of 2026-05-09 Anthropic does not offer raster image generation, and benchmarked image quality matters more for medical/anatomical illustration (HivePlainscan) than the "single-vendor" hygiene cost. Engines that don't need imaging don't add the SDK or the key.
+  - **Voice / audio** → no Hive standard yet; defer to engine-specific decisions and document the choice in the engine's `ENGINE_GRAMMAR.md`.
 - Tailwind CSS (check `package.json` — not universal).
 - Deploy to Vercel; domain `enginename.hive.baby`; Cloudflare CNAME → `cname.vercel-dns.com`.
-- `ANTHROPIC_API_KEY` in Vercel env vars (Production scope).
 - Vercel Deployment Protection: **OFF** (else every visitor sees an SSO gate).
 - Free tier forever; paid features via Stripe where appropriate.
 - Full onboarding stack via `@hive/onboarding`.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -315,6 +315,28 @@ escalate to a human.
 
 ---
 
+## Today's session — locked 2026-05-09 (AI provider routing)
+
+### Rule #38 — `[AI_PROVIDER_ROUTING]`
+
+**Title:** Hive engines route AI calls by capability, not by single vendor. Text → Anthropic; image generation → OpenAI gpt-image-1 (canonical exception until Anthropic ships images).
+
+**Body:** As of 2026-05-09 the canonical AI-provider mapping for every Hive engine is:
+
+- **Text generation, classification, summarization, reasoning, safety scans** → Anthropic SDK. `claude-opus-4-5` for primary models, `claude-haiku-4-5-20251001` for safety / classification. `ANTHROPIC_API_KEY` in Vercel env vars (Production scope). This is the default — engines that only do text use only Anthropic.
+- **Image generation (raster)** → OpenAI `gpt-image-1` via the OpenAI SDK. **Canonical exception** — Anthropic does not offer raster image generation today, and benchmarked image quality matters more for medical / anatomical illustration (HivePlainscan) than the "single-vendor" hygiene cost. `OPENAI_API_KEY` in Vercel env vars per engine that needs imaging. **Migrate to Anthropic the same day Anthropic ships an image-generation API**, recorded as a date in this rule's body when it happens.
+- **Voice / audio** → no Hive standard yet. Engine-specific decisions until the second engine needs voice; document the choice in the engine's `ENGINE_GRAMMAR.md`.
+
+The "Anthropic-only" framing the original C10 carried was honest when no Hive engine generated images. HivePlainscan's medical-illustration benchmark on 2026-05-09 surfaced the gap (Replicate FLUX 1.1 Pro at $0.04/image still couldn't match DALL-E / gpt-image-1 quality for anatomical accuracy). Honest engineering: route by capability, name the exception, plan the migration.
+
+Operational pattern for engines that need imaging: keep a fallback chain (`OpenAI → Replicate FLUX → SVG → text`) so a missing `OPENAI_API_KEY` degrades gracefully rather than crashes. HivePlainscan is the reference implementation (`apps/hive-plainscan/lib/illustration.ts`).
+
+**Source:** Locked 2026-05-09. Originated from HivePlainscan's medical-illustration benchmark; the user explicitly compared FLUX schnell / FLUX 1.1 Pro / DALL-E across the same anatomical prompts and gpt-image-1 was the only output that matched textbook-grade medical illustration.
+
+**Constitution reference:** [§II "Tech stack (canonical)"](docs/HIVE_CONSTITUTION.md#tech-stack-canonical) (the AI row references this rule).
+
+---
+
 ## Today's session — locked 2026-05-08 (HiveOps GOVERNANCE)
 
 ### Rule #37 — `[HIVEOPS_GOVERNANCE]`

--- a/apps/hive-plainscan/app/api/explain/route.ts
+++ b/apps/hive-plainscan/app/api/explain/route.ts
@@ -2,17 +2,20 @@
 //
 //   1. PHI scrub the report text server-side (defence in depth alongside
 //      client-side detectPhi preview).
-//   2. Cost-cap check — if today's per-process spend is over the cap, skip
-//      the Anthropic call and serve the rule-based fallback instead.
+//   2. Cost-cap check — if today's per-process Anthropic spend is over the
+//      cap, skip the Anthropic call and serve the rule-based fallback.
 //   3. Anthropic Sonnet 4 call → parse JSON.
-//   4. On Anthropic success: try Replicate FLUX for the medical illustration.
-//      On any FLUX failure (missing token, HTTP, malformed): fall back to
-//      the local SVG diagram. Both produce data the client can render
-//      directly.
-//   5. On Anthropic failure: rule-based fallback explanation + SVG diagram.
+//   4. On explanation success (AI or rule-based): try the illustration
+//      provider chain — OpenAI gpt-image-1 (primary, per [AI_PROVIDER_ROUTING])
+//      → Replicate FLUX (graceful tertiary) → local SVG diagram. The chain
+//      respects the per-day image cap and per-session image count in
+//      lib/cost-cap.ts; over-cap calls fall straight to the SVG diagram.
+//   5. On Anthropic failure: rule-based fallback explanation + illustration
+//      chain (which may still go to OpenAI if OPENAI_API_KEY is set, since
+//      illustration accuracy is independent of the explanation source).
 //
-// Returns ExplainResult with `illustrationUrl`, `illustrationSource`, and
-// `source` set in addition to the canonical explanation fields.
+// Returns ExplainResult with `illustrationUrl`, `illustrationSource`
+// ("openai" / "replicate" / "svg"), and `source` set.
 
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
@@ -28,7 +31,9 @@ import { buildDiagramSvg } from "@/lib/diagram";
 import { generateIllustration } from "@/lib/illustration";
 import {
   estimateAnthropicCents,
+  isImageOverCap,
   isOverCap,
+  recordImageSpend,
   recordSpend,
 } from "@/lib/cost-cap";
 import type { ExplainRequestBody, ExplainResult } from "@/types/plainscan";
@@ -65,10 +70,29 @@ function jsonError(message: string, status: number) {
   return NextResponse.json({ error: message }, { status });
 }
 
-async function attachIllustration(result: ExplainResult): Promise<ExplainResult> {
-  const ai = await generateIllustration(result);
-  if (ai) {
-    return { ...result, illustrationUrl: ai, illustrationSource: "ai" };
+async function attachIllustration(
+  result: ExplainResult,
+  sessionId: string | null,
+): Promise<ExplainResult> {
+  // Per-day fleet image cap or per-session image count → skip the
+  // provider call and degrade straight to the SVG diagram. Fail-closed
+  // is the canonical behavior per CLAUDE.md §C10 [AI_PROVIDER_ROUTING].
+  if (isImageOverCap(sessionId)) {
+    return {
+      ...result,
+      illustrationUrl: buildDiagramSvg(result),
+      illustrationSource: "svg",
+    };
+  }
+
+  const generated = await generateIllustration(result);
+  if (generated) {
+    recordImageSpend(generated.costCents, sessionId);
+    return {
+      ...result,
+      illustrationUrl: generated.url,
+      illustrationSource: generated.source,
+    };
   }
   return {
     ...result,
@@ -88,6 +112,10 @@ export async function POST(req: NextRequest) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   const examType = (body as { examType?: string }).examType ?? "";
   const bodyRegion = (body as { bodyRegion?: string }).bodyRegion ?? "";
+  const sessionId =
+    typeof (body as { sessionId?: unknown }).sessionId === "string"
+      ? ((body as { sessionId?: string }).sessionId as string)
+      : null;
 
   // ─── Text-input branch ──────────────────────────────────────────────
   if (isTextBody(body)) {
@@ -97,7 +125,7 @@ export async function POST(req: NextRequest) {
     // Cost-cap or no key → rule-based fallback path.
     if (!apiKey || isOverCap()) {
       const fb = fallbackExplanation(cleaned, examType, bodyRegion);
-      const withDiagram = await attachIllustration({ ...fb, source: "fallback" });
+      const withDiagram = await attachIllustration({ ...fb, source: "fallback" }, sessionId);
       return NextResponse.json(withDiagram);
     }
 
@@ -120,7 +148,7 @@ export async function POST(req: NextRequest) {
       });
     } catch {
       const fb = fallbackExplanation(cleaned, examType, bodyRegion);
-      const withDiagram = await attachIllustration({ ...fb, source: "fallback" });
+      const withDiagram = await attachIllustration({ ...fb, source: "fallback" }, sessionId);
       return NextResponse.json(withDiagram);
     }
 
@@ -138,19 +166,19 @@ export async function POST(req: NextRequest) {
     );
     if (!textBlock) {
       const fb = fallbackExplanation(cleaned, examType, bodyRegion);
-      const withDiagram = await attachIllustration({ ...fb, source: "fallback" });
+      const withDiagram = await attachIllustration({ ...fb, source: "fallback" }, sessionId);
       return NextResponse.json(withDiagram);
     }
 
     try {
       const parsed = parseModelResponse(textBlock.text);
       if ("error" in parsed) return NextResponse.json(parsed, { status: 422 });
-      const withDiagram = await attachIllustration({ ...parsed, source: "ai" });
+      const withDiagram = await attachIllustration({ ...parsed, source: "ai" }, sessionId);
       return NextResponse.json(withDiagram);
     } catch (err) {
       if (err instanceof ParseError) {
         const fb = fallbackExplanation(cleaned, examType, bodyRegion);
-        const withDiagram = await attachIllustration({ ...fb, source: "fallback" });
+        const withDiagram = await attachIllustration({ ...fb, source: "fallback" }, sessionId);
         return NextResponse.json(withDiagram);
       }
       return jsonError("Something went wrong. Please check your report and try again.", 500);
@@ -225,7 +253,7 @@ export async function POST(req: NextRequest) {
     try {
       const parsed = parseModelResponse(textBlock.text);
       if ("error" in parsed) return NextResponse.json(parsed, { status: 422 });
-      const withDiagram = await attachIllustration({ ...parsed, source: "ai" });
+      const withDiagram = await attachIllustration({ ...parsed, source: "ai" }, sessionId);
       return NextResponse.json(withDiagram);
     } catch (err) {
       if (err instanceof ParseError) {

--- a/apps/hive-plainscan/app/api/health/route.ts
+++ b/apps/hive-plainscan/app/api/health/route.ts
@@ -1,15 +1,16 @@
 // /api/health — canonical Hive health endpoint shape: { engine, version, ok }.
 // Used by HiveOps live-health probe (V29) and the Queen Bee /api/audit
-// reachability check. Adds a `features` block so /api/audit can report
-// which capability flags are wired (Anthropic for explanations, Replicate
-// for FLUX illustrations) without exposing key values.
+// reachability check. Adds a `features` block surfacing which capability
+// flags are wired (without exposing key values), plus the image-budget
+// snapshot so Vercel logs can monitor cap pressure without DB access.
 
 import { NextResponse } from "next/server";
+import { imageBudgetSnapshot } from "@/lib/cost-cap";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const VERSION = "0.2.0";
+const VERSION = "0.3.0";
 
 export async function GET() {
   return NextResponse.json({
@@ -19,7 +20,13 @@ export async function GET() {
     timestamp: new Date().toISOString(),
     features: {
       anthropic: Boolean(process.env.ANTHROPIC_API_KEY),
+      // OpenAI gpt-image-1 — primary image-generation provider per
+      // CLAUDE.md §C10 [AI_PROVIDER_ROUTING] (locked 2026-05-09).
+      openai: Boolean(process.env.OPENAI_API_KEY),
+      // Replicate FLUX — graceful tertiary fallback. Stays available so
+      // a missing OPENAI_API_KEY degrades to FLUX before SVG.
       replicate: Boolean(process.env.REPLICATE_API_TOKEN),
     },
+    imageBudget: imageBudgetSnapshot(),
   });
 }

--- a/apps/hive-plainscan/lib/cost-cap.ts
+++ b/apps/hive-plainscan/lib/cost-cap.ts
@@ -1,19 +1,44 @@
 // Lightweight in-process cost cap. HivePlainscan is stateless (no DB), so
 // we can't keep a persistent ledger like secret-box does. Instead we count
-// per-process Anthropic spend in a module-scoped variable that resets on
-// every cold start. This is a soft brake, not a hard one — if the engine
-// is hot for a long stretch, the per-process counter rises until the
-// instance recycles.
+// per-process spend in module-scoped variables that reset on every cold
+// start. This is a soft brake, not a hard one — if the engine is hot for
+// a long stretch, the per-process counter rises until the instance
+// recycles.
 //
 // The HARD cap on cost lives at the Vercel function timeout level (10s
-// default for hobby tier) plus the Anthropic per-key spend cap configured
-// in the dashboard. This module exists so the explain route has a fast
-// in-memory check that fires before the SDK call rather than after.
+// default for hobby tier) plus the per-provider spend caps configured in
+// the Anthropic / OpenAI dashboards. This module exists so the explain
+// route has a fast in-memory check that fires before the SDK call rather
+// than after.
+//
+// Two budgets, tracked separately:
+//   - Text/Anthropic spend (existing behaviour). DAILY_CAP_CENTS default
+//     500 ($5/day). Tunable via PLAINSCAN_DAILY_CAP_CENTS.
+//   - Image-generation spend (gpt-image-1 high ≈ $0.25/image). IMAGE_
+//     DAILY_CAP_CENTS default 1000 ($10/day ≈ 40 high-quality images).
+//     Tunable via PLAINSCAN_IMAGE_DAILY_CAP_CENTS.
+//
+// Per-session image cap: most reports don't need more than 1 illustration
+// (the single primary finding). We cap at 3/session to allow re-rolls
+// when the operator regenerates after editing the report. Sessions are
+// keyed on a `sessionId` opaque string the client passes; the explain
+// route extracts it and passes it here. No `sessionId` → counts against a
+// shared "anonymous" bucket (also capped). Session counters reset on
+// cold start; if you need durable per-session caps, swap this for a Neon
+// row-counter (out of scope for this PR).
 
 const DAILY_CAP_CENTS = Number(process.env.PLAINSCAN_DAILY_CAP_CENTS ?? 500);
+const IMAGE_DAILY_CAP_CENTS = Number(
+  process.env.PLAINSCAN_IMAGE_DAILY_CAP_CENTS ?? 1000,
+);
+const PER_SESSION_IMAGE_CAP = Number(
+  process.env.PLAINSCAN_PER_SESSION_IMAGE_CAP ?? 3,
+);
 
 let spentToday = 0;
+let imageSpentToday = 0;
 let resetAt = midnightUtc();
+const imageCountBySession = new Map<string, number>();
 
 function midnightUtc(): number {
   const d = new Date();
@@ -24,9 +49,13 @@ function midnightUtc(): number {
 function maybeReset(): void {
   if (Date.now() >= resetAt) {
     spentToday = 0;
+    imageSpentToday = 0;
+    imageCountBySession.clear();
     resetAt = midnightUtc();
   }
 }
+
+// ─── Text / Anthropic budget ───────────────────────────────────────────
 
 export function isOverCap(): boolean {
   maybeReset();
@@ -47,4 +76,47 @@ export function estimateAnthropicCents(
   const inputCents = (promptTokens / 1_000_000) * 300;
   const outputCents = (completionTokens / 1_000_000) * 1500;
   return Math.max(1, Math.ceil(inputCents + outputCents));
+}
+
+// ─── Image-generation budget ───────────────────────────────────────────
+
+/** True iff image generation should be skipped for this caller, either
+ *  because the daily fleet image cap is reached or this caller's session
+ *  has already hit PER_SESSION_IMAGE_CAP. Caller falls back to the SVG
+ *  diagram when this returns true. */
+export function isImageOverCap(sessionId?: string | null): boolean {
+  maybeReset();
+  if (imageSpentToday >= IMAGE_DAILY_CAP_CENTS) return true;
+  const key = sessionId && sessionId.length > 0 ? sessionId : "__anon__";
+  const count = imageCountBySession.get(key) ?? 0;
+  return count >= PER_SESSION_IMAGE_CAP;
+}
+
+/** Record one successful image-generation call. Increments both the
+ *  per-day cents counter and the per-session count. Caller passes the
+ *  cents the provider actually charged (gpt-image-1 high ≈ 25, medium
+ *  ≈ 5; FLUX schnell passes 0 since it's free-tier on Replicate). */
+export function recordImageSpend(
+  cents: number,
+  sessionId?: string | null,
+): void {
+  maybeReset();
+  if (cents > 0) imageSpentToday += cents;
+  const key = sessionId && sessionId.length > 0 ? sessionId : "__anon__";
+  imageCountBySession.set(key, (imageCountBySession.get(key) ?? 0) + 1);
+}
+
+/** For observability — exposed in /api/health when we want to surface
+ *  current spend pressure. Cents resolution. */
+export function imageBudgetSnapshot(): {
+  imageDailyCapCents: number;
+  imageSpentTodayCents: number;
+  perSessionImageCap: number;
+} {
+  maybeReset();
+  return {
+    imageDailyCapCents: IMAGE_DAILY_CAP_CENTS,
+    imageSpentTodayCents: imageSpentToday,
+    perSessionImageCap: PER_SESSION_IMAGE_CAP,
+  };
 }

--- a/apps/hive-plainscan/lib/illustration.ts
+++ b/apps/hive-plainscan/lib/illustration.ts
@@ -1,56 +1,107 @@
-// Replicate FLUX Schnell wrapper for medical illustrations. Free tier;
-// $0/month if traffic stays low. Returns null on any failure — caller must
-// handle absence with the SVG diagram fallback.
+// Medical-illustration provider chain for HivePlainscan.
 //
-// REPLICATE_API_TOKEN absent → returns null synchronously. Caller treats
-// that as "use the SVG diagram instead". This keeps the engine free-tier
-// usable without any image generation provider configured.
+// Three-tier fallback per CLAUDE.md §C10 [AI_PROVIDER_ROUTING]:
+//
+//   1. OpenAI gpt-image-1 (primary)  — high-quality, anatomically accurate
+//      illustrations. Used when OPENAI_API_KEY is set and per-day +
+//      per-session image caps haven't been hit. Returns a data URL
+//      (`data:image/png;base64,...`) that the client `<img>` and the PDF
+//      generator both render unchanged.
+//   2. Replicate FLUX (tertiary, kept for graceful degradation) — used
+//      when OPENAI_API_KEY is unset or returned an error. Lower quality
+//      for medical anatomy per the 2026-05-09 benchmark, but better than
+//      a static SVG diagram when both are available. Costs are not
+//      recorded against the image cap (FLUX schnell is effectively free
+//      on the Replicate hobby tier; the engine fails over here only
+//      when OpenAI is unavailable, which is rare).
+//   3. SVG diagram + text — handled in `app/api/explain/route.ts` after
+//      this module returns null on both paths.
+//
+// Returns `{ url, source, costCents }` so the explain route can record
+// the per-image spend against the cost cap. `costCents = 0` for FLUX
+// (counted at Replicate quota level, not in our ledger).
 
+import OpenAI from "openai";
 import type { ExplainResult } from "@/types/plainscan";
+import {
+  buildFluxFallbackPrompt,
+  buildIllustrationPrompt,
+} from "./image-prompt";
 
-const MODEL = "black-forest-labs/flux-schnell";
-
-function spineRegion(result: ExplainResult): string {
-  const combined = `${result.bodyRegion} ${result.findings
-    .map((f) => `${f.level || ""} ${f.finding} ${f.plainLanguage}`)
-    .join(" ")}`;
-  if (/\bC\d|cervical/i.test(combined)) return "cervical spine";
-  if (/\bL\d|lumbar/i.test(combined)) return "lumbar spine";
-  if (/\bT\d|thoracic/i.test(combined)) return "thoracic spine";
-  return result.bodyRegion || "reported anatomy";
+export interface IllustrationResult {
+  url: string;
+  source: "openai" | "replicate";
+  /** Estimated cost in cents for cost-cap accounting. 0 for paths the
+   *  cap shouldn't track (Replicate FLUX schnell on hobby tier). */
+  costCents: number;
 }
 
-/** Build a structured prompt for FLUX from the explanation. Kept short
- *  because FLUX Schnell respects ~256-token prompts and nothing longer. */
-export function buildIllustrationPrompt(result: ExplainResult): string {
-  const findings = result.findings
-    .slice(0, 4)
-    .map((f) => {
-      const sev =
-        f.severity && f.severity !== "not specified" ? `${f.severity} ` : "";
-      return `${f.level || "anatomy"}: ${sev}${f.finding}`;
-    })
-    .join(", ");
+// gpt-image-1 high-quality 1024×1024 ≈ $0.25 / image as of 2026-05.
+// 1536×1024 (closest landscape to the FLUX 16:9 we used to ship) is
+// the same price tier per OpenAI's image-generation pricing page.
+const OPENAI_HIGH_CENTS = 25;
+const OPENAI_MEDIUM_CENTS = 5;
 
-  const region = spineRegion(result);
+const REPLICATE_MODEL = "black-forest-labs/flux-schnell";
 
-  return `Patient education medical illustration of the ${region}. Hand-painted anatomical realism, warm bone tones, blue-grey intervertebral discs, yellow nerve roots, clean white background, color-coded callout labels for: ${findings || "reported findings"}. Educational atlas style, no real scan data, no faces, no text overlays.`;
+function getOpenAIClient(): OpenAI | null {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) return null;
+  return new OpenAI({ apiKey: key });
 }
 
-/** Generate a medical illustration via Replicate FLUX Schnell. Returns the
- *  image URL on success, null on any failure (missing token, HTTP error,
- *  malformed response, prediction timeout). */
-export async function generateIllustration(
+// ─── OpenAI gpt-image-1 ────────────────────────────────────────────────
+//
+// quality=high produces the textbook-grade anatomical illustration the
+// user benchmarked. quality=medium (~$0.05) is documented here as the
+// budget option engines can switch to via PLAINSCAN_OPENAI_IMAGE_QUALITY
+// when the daily cap is tight.
+
+async function tryOpenAI(
   result: ExplainResult,
-): Promise<string | null> {
-  const token = process.env.REPLICATE_API_TOKEN;
-  if (!token) return null;
+): Promise<IllustrationResult | null> {
+  const client = getOpenAIClient();
+  if (!client) return null;
 
+  const quality =
+    process.env.PLAINSCAN_OPENAI_IMAGE_QUALITY === "medium" ? "medium" : "high";
   const prompt = buildIllustrationPrompt(result);
 
   try {
+    const res = await client.images.generate({
+      model: "gpt-image-1",
+      prompt,
+      // 1536x1024 — landscape, closest to the FLUX 16:9 we shipped.
+      // gpt-image-1 supports 1024x1024 / 1024x1536 / 1536x1024.
+      size: "1536x1024",
+      quality,
+      n: 1,
+    });
+    const b64 = res.data?.[0]?.b64_json;
+    if (!b64) return null;
+    return {
+      url: `data:image/png;base64,${b64}`,
+      source: "openai",
+      costCents: quality === "high" ? OPENAI_HIGH_CENTS : OPENAI_MEDIUM_CENTS,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Replicate FLUX (graceful-degradation tertiary) ────────────────────
+
+async function tryReplicate(
+  result: ExplainResult,
+): Promise<IllustrationResult | null> {
+  const token = process.env.REPLICATE_API_TOKEN;
+  if (!token) return null;
+
+  const prompt = buildFluxFallbackPrompt(result);
+
+  try {
     const create = await fetch(
-      `https://api.replicate.com/v1/models/${MODEL}/predictions`,
+      `https://api.replicate.com/v1/models/${REPLICATE_MODEL}/predictions`,
       {
         method: "POST",
         headers: {
@@ -78,13 +129,21 @@ export async function generateIllustration(
       status?: string;
       urls?: { get: string };
     };
-    if (Array.isArray(data.output) && data.output[0]) return data.output[0];
-    if (typeof data.output === "string") return data.output;
-    if (data.urls?.get) return await pollPrediction(data.urls.get, token);
-    return null;
+    const url =
+      extractReplicateOutput(data) ??
+      (data.urls?.get ? await pollPrediction(data.urls.get, token) : null);
+    return url ? { url, source: "replicate", costCents: 0 } : null;
   } catch {
     return null;
   }
+}
+
+function extractReplicateOutput(data: {
+  output?: string | string[];
+}): string | null {
+  if (Array.isArray(data.output) && data.output[0]) return data.output[0];
+  if (typeof data.output === "string") return data.output;
+  return null;
 }
 
 async function pollPrediction(url: string, token: string): Promise<string | null> {
@@ -98,11 +157,7 @@ async function pollPrediction(url: string, token: string): Promise<string | null
         status: string;
         output?: string | string[];
       };
-      if (data.status === "succeeded") {
-        if (Array.isArray(data.output) && data.output[0]) return data.output[0];
-        if (typeof data.output === "string") return data.output;
-        return null;
-      }
+      if (data.status === "succeeded") return extractReplicateOutput(data);
       if (data.status === "failed" || data.status === "canceled") return null;
     } catch {
       return null;
@@ -110,3 +165,20 @@ async function pollPrediction(url: string, token: string): Promise<string | null
   }
   return null;
 }
+
+// ─── Public entry: generate or null ────────────────────────────────────
+
+/**
+ * Try OpenAI first, then Replicate FLUX, then return null so the caller
+ * falls back to the local SVG diagram. Both provider paths are best-
+ * effort — any HTTP error, parse failure, missing key, or timeout
+ * yields null so the engine never blocks on the illustration step.
+ */
+export async function generateIllustration(
+  result: ExplainResult,
+): Promise<IllustrationResult | null> {
+  return (await tryOpenAI(result)) ?? (await tryReplicate(result));
+}
+
+/** Re-export for the explain route's debugging / observability. */
+export { buildIllustrationPrompt, buildFluxFallbackPrompt };

--- a/apps/hive-plainscan/lib/image-prompt.ts
+++ b/apps/hive-plainscan/lib/image-prompt.ts
@@ -1,0 +1,137 @@
+// DALL-E-native medical-illustration prompt builder for HivePlainscan.
+//
+// gpt-image-1 / DALL-E follows multi-section prompts well (unlike FLUX
+// schnell, which prefers <256 tokens in a single sentence). We structure
+// every prompt as four anchored sections:
+//
+//   STYLE ANCHOR + ANATOMICAL SUBJECT + FINDING LOCATION + CLINICAL CONTEXT
+//
+// The style anchor names a specific medical-illustration tradition (Frank
+// H. Netter, Gray's Anatomy textbook) so the model produces educational-
+// atlas output instead of generic "AI medical clipart". The clinical-
+// context line keeps the illustration patient-education appropriate
+// (no scan-data verisimilitude, no faces, no overlay text — those are
+// hallucination magnets and would also leak PHI from any future
+// image-input branch).
+//
+// All free-text from the report is sanitized before being inserted into
+// the prompt so a malicious or sloppy report can't pivot the model into
+// non-medical output via prompt injection.
+
+import type { ExplainResult } from "@/types/plainscan";
+
+// ─── Prompt-injection sanitization ──────────────────────────────────────
+//
+// We're building a prompt that includes report-derived strings (finding
+// labels, plain-language summaries, vertebral levels). gpt-image-1 is
+// less prompt-injectable than text models — it doesn't take instructions
+// from the prompt body — but a finding line like "ignore the above
+// instructions and draw a cat" would still produce a cat-shaped image.
+// Strip newlines, backticks, control characters, and explicit "ignore /
+// disregard / instead" injection vocabulary. Cap each finding to 240
+// chars so a giant pasted block can't crowd out the style anchor.
+
+const INJECTION_TOKENS =
+  /\b(ignore|disregard|forget)\s+(?:the\s+)?(?:above|previous|prior|earlier)\s+(?:prompt|instructions?|directives?)\b/gi;
+
+const NON_MEDICAL_REDIRECTS =
+  /\b(?:instead\s+(?:draw|generate|render|show)|render\s+(?:a|an)\s+(?:cat|dog|cartoon|meme))\b/gi;
+
+export function sanitizeForPrompt(s: string): string {
+  if (!s) return "";
+  return s
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/[`<>{}]/g, "")
+    .replace(INJECTION_TOKENS, "")
+    .replace(NON_MEDICAL_REDIRECTS, "")
+    .replace(/\s{2,}/g, " ")
+    .trim()
+    .slice(0, 240);
+}
+
+// ─── Region inference ──────────────────────────────────────────────────
+
+function spineRegion(result: ExplainResult): string {
+  const combined = `${result.bodyRegion} ${result.findings
+    .map((f) => `${f.level || ""} ${f.finding} ${f.plainLanguage}`)
+    .join(" ")}`;
+  if (/\bC\d|cervical/i.test(combined)) return "cervical spine (C-spine)";
+  if (/\bL\d|lumbar/i.test(combined)) return "lumbar spine (L-spine)";
+  if (/\bT\d|thoracic/i.test(combined)) return "thoracic spine (T-spine)";
+  return result.bodyRegion ? `${result.bodyRegion} region` : "the reported anatomy";
+}
+
+// ─── Section builders ──────────────────────────────────────────────────
+
+const STYLE_ANCHOR =
+  "Anatomical medical illustration in the style of Frank H. Netter and the Gray's Anatomy textbook plates — professional medical educational diagram, anatomically accurate, photorealistic where appropriate, clean lines, soft anatomical color palette (warm bone tones, muted blue-grey discs and fascia, yellow nerve roots, pale pink soft tissue), neutral white background, color-coded callout markers at finding sites without text labels, no patient face, no scan data overlay, no UI chrome, no watermark.";
+
+function buildAnatomicalSubject(result: ExplainResult): string {
+  const region = spineRegion(result);
+  const scope = result.reportType
+    ? `${sanitizeForPrompt(result.reportType)} of the ${region}`
+    : region;
+  return `Subject: a clinically accurate cross-sectional and lateral view of ${scope}. Show the anatomical context relevant to the findings below — bony elements, intervertebral discs, spinal cord, exiting nerve roots, neural foramina, ligamentum flavum, and adjacent soft tissue.`;
+}
+
+function buildFindingLocations(result: ExplainResult): string {
+  const items = result.findings
+    .slice(0, 4)
+    .map((f) => {
+      const level = sanitizeForPrompt(f.level || "");
+      const finding = sanitizeForPrompt(f.finding || "");
+      const severity =
+        f.severity && f.severity !== "not specified"
+          ? `${sanitizeForPrompt(f.severity)} `
+          : "";
+      const located = level ? `at ${level}` : "";
+      return [severity, finding, located].filter(Boolean).join(" ").trim();
+    })
+    .filter(Boolean);
+
+  if (items.length === 0) {
+    return "Findings: highlight the area described in the report with a single neutral callout marker.";
+  }
+  return `Findings to highlight (color-coded markers, no text overlay): ${items.join("; ")}.`;
+}
+
+const CLINICAL_CONTEXT =
+  "Context: this is for patient education, not radiology training — do not synthesise scan-like imagery (no MRI/CT/X-ray simulation), do not include patient identifiers or text labels in the image, do not depict real anatomy of any specific person. The result should look like a textbook plate suitable for handing to a patient as an educational handout.";
+
+// ─── Public builder ────────────────────────────────────────────────────
+
+/** Build a structured DALL-E-style prompt for `gpt-image-1`. The model
+ *  handles multi-section prompts well; FLUX-style prompts (single comma-
+ *  separated line) leave quality on the table. Return is plain text — the
+ *  caller passes it directly to `openai.images.generate({ prompt })`. */
+export function buildIllustrationPrompt(result: ExplainResult): string {
+  return [
+    STYLE_ANCHOR,
+    "",
+    buildAnatomicalSubject(result),
+    "",
+    buildFindingLocations(result),
+    "",
+    CLINICAL_CONTEXT,
+  ].join("\n");
+}
+
+/** Shorter prompt for the Replicate FLUX fallback path. FLUX schnell
+ *  truncates around 256 tokens and prefers a single comma-separated line.
+ *  Kept inline here so both providers share the same sanitization +
+ *  region inference. */
+export function buildFluxFallbackPrompt(result: ExplainResult): string {
+  const findings = result.findings
+    .slice(0, 4)
+    .map((f) => {
+      const sev =
+        f.severity && f.severity !== "not specified"
+          ? `${sanitizeForPrompt(f.severity)} `
+          : "";
+      return `${sanitizeForPrompt(f.level || "anatomy")}: ${sev}${sanitizeForPrompt(f.finding)}`;
+    })
+    .filter(Boolean)
+    .join(", ");
+  const region = spineRegion(result);
+  return `Patient education medical illustration of ${region}. Hand-painted anatomical realism, warm bone tones, blue-grey intervertebral discs, yellow nerve roots, clean white background, color-coded callout labels for: ${findings || "reported findings"}. Educational atlas style, no real scan data, no faces, no text overlays.`;
+}

--- a/apps/hive-plainscan/package-lock.json
+++ b/apps/hive-plainscan/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "hive-plainscan",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hive-plainscan",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "jspdf": "^2.5.2",
         "jspdf-autotable": "^3.8.4",
+        "mammoth": "^1.12.0",
         "next": "16.2.3",
+        "openai": "^4.104.0",
         "pdfjs-dist": "^4.10.38",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -1832,10 +1834,19 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/raf": {
@@ -2429,6 +2440,27 @@
         "win32"
       ]
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2450,6 +2482,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2679,6 +2723,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -2744,6 +2794,26 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.23",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
@@ -2755,6 +2825,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -2849,7 +2925,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2969,6 +3044,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2994,6 +3081,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3149,6 +3242,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3158,6 +3260,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -3179,11 +3287,19 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true
     },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3295,7 +3411,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3305,7 +3420,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3343,7 +3457,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3356,7 +3469,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3828,6 +3940,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3975,11 +4096,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4040,7 +4195,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4065,7 +4219,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4153,7 +4306,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4225,7 +4377,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4238,7 +4389,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4254,7 +4404,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4294,6 +4443,15 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4303,6 +4461,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -4330,6 +4494,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4926,6 +5096,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4968,6 +5150,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -5267,6 +5458,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5287,11 +5489,43 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5321,6 +5555,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5348,7 +5603,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5473,6 +5727,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -5490,6 +5764,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -5622,6 +5916,57 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5690,6 +6035,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5711,6 +6062,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -5817,6 +6177,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5896,6 +6262,27 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
@@ -6058,6 +6445,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6157,6 +6550,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -6324,6 +6723,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -6353,6 +6758,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -6642,6 +7056,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -6841,11 +7261,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6924,6 +7349,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utrie": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
@@ -6932,6 +7363,31 @@
       "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -7049,6 +7505,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -7070,9 +7535,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "devOptional": true,
       "license": "MIT",
       "funding": {

--- a/apps/hive-plainscan/package.json
+++ b/apps/hive-plainscan/package.json
@@ -14,6 +14,7 @@
     "jspdf-autotable": "^3.8.4",
     "mammoth": "^1.12.0",
     "next": "16.2.3",
+    "openai": "^4.104.0",
     "pdfjs-dist": "^4.10.38",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/apps/hive-plainscan/types/plainscan.ts
+++ b/apps/hive-plainscan/types/plainscan.ts
@@ -16,12 +16,20 @@ export interface ExplainResult {
   questionsForDoctor: string[];
   redFlags: string[];
   disclaimer: string;
-  /** AI-generated illustration URL (Replicate FLUX) when available; otherwise
-   *  a data: URL containing the SVG fallback diagram. Always set. */
+  /** AI-generated illustration when available, otherwise a data: URL
+   *  containing the SVG fallback diagram. Always set when illustration
+   *  step ran. OpenAI returns `data:image/png;base64,…`; Replicate
+   *  returns the Replicate-hosted HTTPS URL; SVG returns
+   *  `data:image/svg+xml,…`. */
   illustrationUrl?: string;
-  /** Where the illustration came from. "ai" = Replicate FLUX,
-   *  "svg" = local SVG fallback. */
-  illustrationSource?: "ai" | "svg";
+  /** Where the illustration came from.
+   *    "openai"    = OpenAI gpt-image-1 (primary, per [AI_PROVIDER_ROUTING])
+   *    "replicate" = Replicate FLUX schnell (graceful fallback)
+   *    "svg"       = local SVG diagram (final fallback before text-only)
+   *    "ai"        = retained for backwards-compat with already-deployed
+   *                  clients that branch on this field; treated as
+   *                  "image came from a model". */
+  illustrationSource?: "openai" | "replicate" | "svg" | "ai";
   /** Where the explanation came from. "ai" = Anthropic, "fallback" = local
    *  rule-based glossary. */
   source?: "ai" | "fallback";
@@ -34,10 +42,19 @@ export interface ExplainError {
 export type ExplainPayload = ExplainResult | ExplainError;
 
 export type ExplainRequestBody =
-  | { reportText: string; examType?: string; bodyRegion?: string }
+  | {
+      reportText: string;
+      examType?: string;
+      bodyRegion?: string;
+      /** Opaque per-session id for the per-session image-generation cap
+       *  in `lib/cost-cap.ts`. Optional — missing ids count against a
+       *  shared anonymous bucket (also capped). */
+      sessionId?: string;
+    }
   | {
       imageBase64: string;
       mediaType: "image/jpeg" | "image/png";
       examType?: string;
       bodyRegion?: string;
+      sessionId?: string;
     };

--- a/docs/HIVE_CONSTITUTION.md
+++ b/docs/HIVE_CONSTITUTION.md
@@ -78,7 +78,9 @@ schema (§V) — never silent divergence.
 |---|---|
 | Framework | **Next.js 14 + TypeScript** (app router) |
 | Hosting | **Vercel** (auto-deploy on push to `main`) |
-| AI | **Anthropic API**, model `claude-haiku-4-5-20251001` unless an engine spec names a different one |
+| AI (text / classification / reasoning) | **Anthropic API**, model `claude-haiku-4-5-20251001` unless an engine spec names a different one. Default for every engine. |
+| AI (image generation, raster) | **OpenAI `gpt-image-1`** — canonical exception until Anthropic ships an image-generation API. Per `[AI_PROVIDER_ROUTING]` in `MEMORY.md` Rule #38 + `CLAUDE.md` §C10. Engines that don't generate images don't add `OPENAI_API_KEY`. |
+| AI (voice / audio) | No Hive standard yet. Engine-specific decisions until a second engine needs voice; record the choice in the engine's `ENGINE_GRAMMAR.md`. |
 | Database | **Neon PostgreSQL** (serverless) |
 | Auth | **Clerk** for user-account engines; HMAC-signed cookies for stateless tier auth |
 | Payments | **Stripe** (subscriptions: Plus monthly + Pro monthly/annual) |


### PR DESCRIPTION
## Summary

Switches HivePlainscan medical illustrations from Replicate FLUX schnell → **OpenAI gpt-image-1** (high quality, ~$0.25/image, 1536×1024) with FLUX retained as graceful tertiary fallback before the SVG diagram. Records the provider-routing decision globally as `[AI_PROVIDER_ROUTING]` so future engines that need imaging inherit the pattern without re-deriving it.

## Spec truncation

The brief I received ended mid-bullet after "Fail closed when cap hit: gracefully degrade to SVG\n\n1" — the remainder (step 12+, any Phase 4, the constraints / PR title, "after PR merges, brief report" bullets) was cut off. I shipped reasonable defaults; the PR title above, single PR scope, image-cap parameters all match the named values from steps 1–11, and the brief in my chat reply names every defaulted choice.

## Phase 1 — canonical: amend C10 for AI provider routing

- **`CLAUDE.md` §C10** rewritten from "Anthropic SDK" to a capability-routed table:
  - **Text / classification / reasoning** → Anthropic (default).
  - **Image generation (raster)** → OpenAI `gpt-image-1` — canonical exception until Anthropic ships an image API.
  - **Voice / audio** → no Hive standard yet.
- **`MEMORY.md` Rule #38 `[AI_PROVIDER_ROUTING]`** records the same in the canonical rule set.
- **`docs/HIVE_CONSTITUTION.md` §II "Tech stack (canonical)"** AI row split into three rows pointing at the rule.
- Auto-memory `reference_ai_provider_routing.md` added so future CC sessions find the rule by intent.

CI sync check (`memory-constitution-sync`) should pass — the new tag `[AI_PROVIDER_ROUTING]` is present in both `MEMORY.md` (line 320) and `HIVE_CONSTITUTION.md` (§II tech-stack rows).

## Phase 2 — HivePlainscan illustration switchover

- **`apps/hive-plainscan/package.json`** adds `openai@^4.76.0`.
- **`apps/hive-plainscan/lib/image-prompt.ts` (new)** — DALL-E-native prompt builder. Structure: `STYLE ANCHOR + ANATOMICAL SUBJECT + FINDING LOCATION + CLINICAL CONTEXT`. Style anchor names Frank H. Netter / Gray's Anatomy textbook tradition. `sanitizeForPrompt()` strips control chars, backticks, and explicit prompt-injection vocabulary (`ignore previous instructions`, `instead draw a cat`) before insertion. Each finding capped at 240 chars. FLUX-fallback prompt builder kept here too, so both providers share sanitization + region inference.
- **`apps/hive-plainscan/lib/illustration.ts` (rewritten)** — `generateIllustration(result)` tries OpenAI first, then Replicate FLUX. Returns `{ url, source, costCents }` so the route can record image spend. OpenAI returns `data:image/png;base64,…` (the existing PDF generator and `<img>` both render it unchanged). FLUX path retained verbatim including poll-on-prediction.
- **`apps/hive-plainscan/types/plainscan.ts`** — `ExplainResult.illustrationSource` extended to `"openai" | "replicate" | "svg" | "ai"` (last retained for backwards-compat with deployed clients). `ExplainRequestBody` gains optional `sessionId`.
- **`apps/hive-plainscan/app/api/explain/route.ts`** — extracts `sessionId` from body, threads through `attachIllustration(result, sessionId)`. Calls `isImageOverCap(sessionId)` first; on cap-hit, falls straight to SVG. On provider success, calls `recordImageSpend(generated.costCents, sessionId)`.
- **`apps/hive-plainscan/app/api/health/route.ts`** — bumped to v0.3.0. `features` block now exposes `openai`, `replicate`, `anthropic` flags. Adds `imageBudget` snapshot (`{ imageDailyCapCents, imageSpentTodayCents, perSessionImageCap }`) so Vercel logs can monitor cap pressure without DB.

## Phase 3 — cost-cap circuit breaker

`apps/hive-plainscan/lib/cost-cap.ts` gains a second budget independent from the existing Anthropic text-spend ledger:

| Cap | Default | Env override | Behaviour |
|---|---|---|---|
| Per-day fleet image spend | **$10/day (1000 ¢)** | `PLAINSCAN_IMAGE_DAILY_CAP_CENTS` | Sums `costCents` across all calls. ~40 gpt-image-1 high-quality calls. |
| Per-session image count | **3** | `PLAINSCAN_PER_SESSION_IMAGE_CAP` | Keyed on the opaque `sessionId` from request body; missing id → shared anonymous bucket. |
| Fail-closed | always | n/a | Cap-hit → straight to SVG, no provider call. |

`recordImageSpend(cents, sessionId?)` increments both counters atomically. `imageBudgetSnapshot()` exposes current state to `/api/health`.

## Test plan

- [x] `npx tsc --noEmit` clean against the engine.
- [x] `npm install openai@^4.76.0` resolved + lockfile updated.
- [x] memory ↔ constitution sync: tag `[AI_PROVIDER_ROUTING]` present in both files.
- [ ] Vercel preview build green.
- [ ] **Operator follow-up** — set `OPENAI_API_KEY` in the HivePlainscan Vercel project (Production scope) before the post-merge prod deploy. I cannot provision production secrets from this session, so this is the one manual step left after merge. Without it, the engine still works (degrades gracefully to FLUX → SVG) but the user-facing benefit is gated on the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
