### PR TITLE
HiveBuyStuff: E2E Playwright suite + V2 spec

### DIFF
--- a/.github/workflows/hivebuystuff-e2e.yml
+++ b/.github/workflows/hivebuystuff-e2e.yml
@@ -1,0 +1,55 @@
+name: HiveBuyStuff — E2E Tests
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["HiveBuyStuff Deploy and Migrate"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  e2e:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Playwright + deps
+        working-directory: hive-hivebuystuff
+        run: |
+          npm install --legacy-peer-deps
+          npx playwright install chromium --with-deps
+
+      - name: Wait for deployment to be live
+        run: |
+          echo "Waiting for hivebuystuff.hive.baby to be ready..."
+          for i in $(seq 1 24); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://hivebuystuff.hive.baby/api/health" --max-time 10)
+            echo "  [$i/24] HTTP $STATUS"
+            if [ "$STATUS" = "200" ]; then
+              echo "✓ Site is live"
+              break
+            fi
+            sleep 10
+          done
+
+      - name: Run E2E tests
+        working-directory: hive-hivebuystuff
+        env:
+          BASE_URL: https://hivebuystuff.hive.baby
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx playwright test --reporter=list
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: hive-hivebuystuff/playwright-report/
+          retention-days: 7

--- a/docs/hivebuystuff-v2-spec.md
+++ b/docs/hivebuystuff-v2-spec.md
@@ -1,0 +1,130 @@
+# HiveBuyStuff V2 — Chrome Extension + Magic Key
+
+**Status:** Specced 2026-05-15. Starts after V1 E2E green.
+
+---
+
+## V2 goal
+
+Move from "search URL links" (V1) to **real cart on every site** — no store partnership required.
+Revenue path: Amazon PA-API affiliate commissions + Stripe Pro/Premium.
+Zero per-run infrastructure cost on the extension path.
+
+---
+
+## V2.1 — Magic Key (portable identity, server-side)
+
+**Why:** localStorage wipes destroy all user data. Users can't move between devices.
+
+**How:**
+- `hbs_magic_keys` table: `key_hash TEXT PRIMARY KEY, user_id TEXT NOT NULL, created_at TIMESTAMPTZ`
+- Key is SHA-256 HMAC'd with `CRON_SECRET` before storage (no plaintext keys in DB ever)
+- Min length 8 chars enforced client + server
+- UI: "Sync across devices" card in Settings — user sets a key, enters it on next device
+- `POST /api/hbs/magic-key` — set key for user_id (idempotent: updates if user_id matches, 409 if key taken by different user)
+- `GET /api/hbs/magic-key?key=xxx` — returns `{user_id}` if found
+- On second device: enter key → fetch user_id → write to localStorage → all data appears
+
+**No email. No OAuth. No third party. Cost: $0.**
+
+---
+
+## V2.2 — Chrome Extension (real cart, every site)
+
+**Why:** Honey model. User installs once. Extension has their cookies. No per-run cost.
+No store API partnership needed. Works on Amazon, Walmart, Target, Instacart, Kroger, and every other retailer.
+
+**Architecture:**
+```
+HiveBuyStuff web app
+  → "Open in extension" button on cart result
+  → message passes mapped item list to extension via postMessage / chrome.runtime
+
+Chrome extension (Manifest V3)
+  → content script on retailer checkout/search page
+  → reads mapped items from web app message
+  → adds items to cart by clicking "Add to cart" buttons via DOM automation
+  → reports back: N items added, M failed
+```
+
+**Extension → web app communication:**
+- Web app generates a one-time token stored in `hbs_ext_pending` (localStorage + `/api/hbs/ext/session`)
+- Extension polls for pending sessions → executes → posts result back
+- No persistent server connection needed
+
+**Stores in V2.2 (by DOM stability, easiest first):**
+1. Amazon — `#add-to-cart-button` (stable)
+2. Walmart — `[data-automation-id="add-to-cart-button"]`
+3. Target — `.AddToCartButton`
+4. Kroger — `[data-testid="CartButton"]`
+5. Instacart — `[data-testid="add-item-button"]`
+
+**Revenue:** Amazon PA-API affiliate links. Extension replaces cart_url with PA-API product link before opening. ~3–8% commission on purchases. Zero cost per run.
+
+**Timeline:** Manifest V3 Chrome extension, ~400 lines. Firefox port is the same codebase via `webextension-polyfill`.
+
+---
+
+## V2.3 — Amazon PA-API Affiliate Integration
+
+**Why:** Passive revenue on every Amazon cart run, even without the extension.
+
+**How:**
+- `AMAZON_ASSOCIATE_TAG` env var (free to get from Amazon Associates)
+- When routing to Amazon, append `&tag=ASSOCIATE_TAG` to cart_url
+- PA-API (optional, richer): search by ASIN, get real product links, real prices
+- Revenue: 3–8% on anything purchased within 24h of click
+
+**API credentials needed:** Amazon Associates account (free), PA-API key + secret.
+
+---
+
+## V2.4 — Kroger OAuth2 + Real Cart API
+
+**Why:** Only major retailer with a public OAuth2 + cart API. Real "Add to cart" without extension.
+
+**Kroger API (developer.kroger.com):**
+- `POST /v1/cart/add` with `items: [{upc, quantity}]`
+- Requires user OAuth2 token (Kroger account login via HiveBuyStuff)
+- Free developer tier: 10,000 API calls/month
+
+**Flow:**
+1. User connects Kroger account (OAuth2 PKCE flow)
+2. We store `kroger_access_token` + `kroger_refresh_token` in `hbs_subscriptions`
+3. On cart run → Kroger backend → AI maps items → fetch UPCs from Kroger product search → `POST /v1/cart/add`
+4. User opens Kroger app/site → cart is ready
+
+**Only real "cart populated" experience possible without extension in V2.**
+
+---
+
+## V2.5 — Run limit bypass via usage token (anti-abuse)
+
+For Pro/Premium: replace monthly counter with a rolling 30-day window.
+Prevents "reset on 1st of month" gaming.
+
+---
+
+## Sequencing
+
+| Phase | Feature | Effort | Revenue impact |
+|-------|---------|--------|----------------|
+| V2.1 | Magic key | 1 day | Retention |
+| V2.2 | Chrome extension | 3–4 days | Honey-model affiliate |
+| V2.3 | Amazon PA-API | 1 day | Direct revenue |
+| V2.4 | Kroger OAuth2 | 2 days | Real cart (no extension) |
+| V2.5 | Rolling window | 0.5 day | Abuse prevention |
+
+**Start with V2.1 (magic key) immediately — zero risk, instant user value.**
+**V2.2 (extension) is the Honey play — build in parallel once E2E is green.**
+
+---
+
+## What V2 is NOT
+
+- Computer Use (Anthropic) — too expensive per run for base tier, no free path
+- MultiOn / Steel.dev — paid per-session, same problem
+- Server-side headless browser — anti-bot blocked on major retailers, no user credentials
+- Standalone app — the web app + extension combo is the right architecture
+
+The Chrome extension IS the free computer use. It runs in the user's browser with their own session. That's how Honey works. That's how we work.

--- a/hive-hivebuystuff/e2e/cart.spec.ts
+++ b/hive-hivebuystuff/e2e/cart.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+import { randomUUID } from "crypto";
+
+const BASE = process.env.BASE_URL ?? "https://hivebuystuff.hive.baby";
+const USER_ID = `e2e-cart-${randomUUID()}`;
+
+test.describe("Cart routing", () => {
+  let templateId: string;
+
+  test.beforeAll(async ({ request }) => {
+    const res = await request.post(`${BASE}/api/hbs/templates`, {
+      data: {
+        user_id: USER_ID,
+        name: "E2E Cart Test",
+        items: [
+          { name: "whole milk 1 gallon", quantity: 1, unit: null, brand_tier: "budget", perishable: true, substitution_allowed: true },
+          { name: "sliced bread", quantity: 1, unit: null, brand_tier: "budget", perishable: false, substitution_allowed: true },
+        ],
+      },
+    });
+    expect(res.status()).toBe(201);
+    templateId = (await res.json()).id;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (templateId) {
+      await request.delete(`${BASE}/api/hbs/templates/${templateId}`, {
+        data: { user_id: USER_ID },
+      });
+    }
+  });
+
+  for (const backend of ["walmart", "target", "amazon", "instacart"]) {
+    test(`AI routes to ${backend} and returns valid cart`, async ({ request }) => {
+      const res = await request.post(`${BASE}/api/hbs/route`, {
+        data: { template_id: templateId, backend, user_id: USER_ID },
+      });
+      expect(res.status()).toBe(200);
+      const cart = await res.json();
+      expect(cart.backend).toBe(backend);
+      expect(Array.isArray(cart.items)).toBe(true);
+      expect(cart.items.length).toBeGreaterThan(0);
+      expect(typeof cart.cart_url).toBe("string");
+      expect(cart.cart_url).toContain("http");
+      // Each item has original, mapped, qty
+      for (const item of cart.items) {
+        expect(item.original).toBeTruthy();
+        expect(item.mapped).toBeTruthy();
+        expect(typeof item.qty).toBe("number");
+      }
+    });
+  }
+
+  test("usage increments after each run", async ({ request }) => {
+    const before = await request.get(`${BASE}/api/hbs/usage?user_id=${USER_ID}`);
+    const beforeCount = (await before.json()).run_count;
+
+    await request.post(`${BASE}/api/hbs/route`, {
+      data: { template_id: templateId, backend: "walmart", user_id: USER_ID },
+    });
+
+    const after = await request.get(`${BASE}/api/hbs/usage?user_id=${USER_ID}`);
+    const afterCount = (await after.json()).run_count;
+    expect(afterCount).toBeGreaterThan(beforeCount);
+  });
+});

--- a/hive-hivebuystuff/e2e/health.spec.ts
+++ b/hive-hivebuystuff/e2e/health.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test";
+
+test("health endpoint returns ok + HiveBuyStuff engine", async ({ request }) => {
+  const res = await request.get("/api/health");
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  expect(body.status).toBe("ok");
+  expect(body.engine).toBe("HiveBuyStuff");
+});

--- a/hive-hivebuystuff/e2e/landing.spec.ts
+++ b/hive-hivebuystuff/e2e/landing.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+
+test("landing page loads with canonical branding", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle(/HiveBuyStuff/);
+  // Hive logo present
+  await expect(page.locator('img[alt="Hive ecosystem"]')).toBeVisible();
+  // Engine wordmark
+  await expect(page.getByText("HiveBuyStuff", { exact: false })).toBeVisible();
+  // Backend showcase visible
+  await expect(page.getByText("Walmart")).toBeVisible();
+  await expect(page.getByText("Target")).toBeVisible();
+  await expect(page.getByText("Amazon")).toBeVisible();
+  await expect(page.getByText("Instacart")).toBeVisible();
+  await expect(page.getByText("Kroger")).toBeVisible();
+  // Tabs visible
+  await expect(page.getByRole("tab", { name: "My Lists" })).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Run a Cart" })).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Settings" })).toBeVisible();
+  // Canonical footer
+  await expect(page.getByText(/Made with/)).toBeVisible();
+  await expect(page.getByText(/No ads/)).toBeVisible();
+});
+
+test("manifest.json has canonical theme_color", async ({ request }) => {
+  const res = await request.get("/manifest.json");
+  expect(res.status()).toBe(200);
+  const manifest = await res.json();
+  expect(manifest.theme_color).toBe("#D4AF37");
+  expect(manifest.name).toBe("HiveBuyStuff");
+  expect(manifest.display).toBe("standalone");
+});
+
+test("first visit card appears then dismisses", async ({ page }) => {
+  // Clear localStorage to simulate first visit
+  await page.goto("/");
+  await page.evaluate(() => localStorage.removeItem("hbs_welcomed_hivebuystuff"));
+  await page.reload();
+  const card = page.getByText("Build once. Buy anywhere.", { exact: false }).first();
+  await expect(card).toBeVisible({ timeout: 5000 });
+  // Dismiss
+  await page.getByText("Got it").click();
+  await expect(card).not.toBeVisible({ timeout: 3000 });
+  // Reload — card should not reappear
+  await page.reload();
+  await page.waitForTimeout(1000);
+  await expect(page.getByText("Create my first list →")).not.toBeVisible();
+});

--- a/hive-hivebuystuff/e2e/settings.spec.ts
+++ b/hive-hivebuystuff/e2e/settings.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+import { randomUUID } from "crypto";
+
+const BASE = process.env.BASE_URL ?? "https://hivebuystuff.hive.baby";
+const USER_ID = `e2e-settings-${randomUUID()}`;
+
+test.describe("Settings", () => {
+  test("save and reload preferences round-trips correctly", async ({ request }) => {
+    const saveRes = await request.post(`${BASE}/api/hbs/preferences`, {
+      data: {
+        user_id: USER_ID,
+        substitution_tolerance: "strict",
+        dietary_rules: ["gluten-free", "no pork"],
+        budget_ceiling: 75,
+        preferred_backends: ["Walmart", "Target"],
+      },
+    });
+    expect(saveRes.status()).toBe(200);
+
+    const getRes = await request.get(`${BASE}/api/hbs/preferences?user_id=${USER_ID}`);
+    expect(getRes.status()).toBe(200);
+    const prefs = await getRes.json();
+    expect(prefs.substitution_tolerance).toBe("strict");
+    expect(prefs.dietary_rules).toContain("gluten-free");
+    expect(prefs.dietary_rules).toContain("no pork");
+    expect(Number(prefs.budget_ceiling)).toBe(75);
+    expect(prefs.preferred_backends).toContain("Walmart");
+    expect(prefs.preferred_backends).toContain("Target");
+  });
+
+  test("settings UI loads and shows tolerance options", async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate((uid) => localStorage.setItem("hbs_user_id", uid), USER_ID);
+    await page.reload();
+
+    await page.getByRole("tab", { name: "Settings" }).click();
+    await expect(page.getByText("How flexible are you with swaps?")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("strict", { exact: false })).toBeVisible();
+    await expect(page.getByText("flexible", { exact: false })).toBeVisible();
+    await expect(page.getByText("auto", { exact: false })).toBeVisible();
+    // Preferred stores listed
+    await expect(page.getByText("Walmart")).toBeVisible();
+    await expect(page.getByText("Kroger")).toBeVisible();
+  });
+});

--- a/hive-hivebuystuff/e2e/templates.spec.ts
+++ b/hive-hivebuystuff/e2e/templates.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test";
+import { randomUUID } from "crypto";
+
+const BASE = process.env.BASE_URL ?? "https://hivebuystuff.hive.baby";
+const USER_ID = `e2e-${randomUUID()}`;
+
+test.describe("Template CRUD", () => {
+  test("create a list via API and it appears in UI", async ({ page, request }) => {
+    // Create template via API
+    const res = await request.post(`${BASE}/api/hbs/templates`, {
+      data: {
+        user_id: USER_ID,
+        name: "E2E Groceries",
+        items: [
+          { name: "whole milk", quantity: 1, unit: "gallon", brand_tier: "budget", perishable: true, substitution_allowed: true },
+          { name: "bananas", quantity: 6, unit: null, brand_tier: "budget", perishable: true, substitution_allowed: true },
+        ],
+      },
+    });
+    expect(res.status()).toBe(201);
+    const tmpl = await res.json();
+    expect(tmpl.name).toBe("E2E Groceries");
+    const templateId = tmpl.id;
+
+    // Seed user_id into page localStorage then load
+    await page.goto("/");
+    await page.evaluate((uid) => localStorage.setItem("hbs_user_id", uid), USER_ID);
+    await page.reload();
+
+    // Template card should appear
+    await expect(page.getByText("E2E Groceries")).toBeVisible({ timeout: 8000 });
+
+    // Clean up
+    await request.delete(`${BASE}/api/hbs/templates/${templateId}`, {
+      data: { user_id: USER_ID },
+    });
+  });
+
+  test("delete template enforces ownership — wrong user_id returns 404", async ({ request }) => {
+    const createRes = await request.post(`${BASE}/api/hbs/templates`, {
+      data: {
+        user_id: USER_ID,
+        name: "E2E Delete Guard",
+        items: [{ name: "eggs", quantity: 12, unit: null, brand_tier: "mid", perishable: true, substitution_allowed: false }],
+      },
+    });
+    const tmpl = await createRes.json();
+
+    const delRes = await request.delete(`${BASE}/api/hbs/templates/${tmpl.id}`, {
+      data: { user_id: "wrong-user-id" },
+    });
+    expect(delRes.status()).toBe(404);
+
+    // Clean up with correct user
+    await request.delete(`${BASE}/api/hbs/templates/${tmpl.id}`, {
+      data: { user_id: USER_ID },
+    });
+  });
+
+  test("free tier: 4th list creation returns 429 upgrade_required", async ({ request }) => {
+    const listNames = ["FT List 1", "FT List 2", "FT List 3"];
+    const ids: string[] = [];
+    const ftUser = `e2e-ft-${randomUUID()}`;
+
+    // Create 3 lists (free tier max)
+    for (const name of listNames) {
+      const res = await request.post(`${BASE}/api/hbs/templates`, {
+        data: { user_id: ftUser, name, items: [{ name: "milk", quantity: 1, unit: null, brand_tier: "budget", perishable: true, substitution_allowed: true }] },
+      });
+      expect(res.status()).toBe(201);
+      ids.push((await res.json()).id);
+    }
+
+    // 4th list should be blocked
+    const blocked = await request.post(`${BASE}/api/hbs/templates`, {
+      data: { user_id: ftUser, name: "FT List 4", items: [{ name: "bread", quantity: 1, unit: null, brand_tier: "budget", perishable: false, substitution_allowed: true }] },
+    });
+    expect(blocked.status()).toBe(429);
+    const err = await blocked.json();
+    expect(err.upgrade_required).toBe(true);
+
+    // Clean up
+    for (const id of ids) {
+      await request.delete(`${BASE}/api/hbs/templates/${id}`, { data: { user_id: ftUser } });
+    }
+  });
+});

--- a/hive-hivebuystuff/package-lock.json
+++ b/hive-hivebuystuff/package-lock.json
@@ -16,6 +16,7 @@
         "stripe": "^17.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1279,6 +1280,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3673,6 +3690,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4971,6 +5003,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5434,16 +5479,48 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6288,19 +6365,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6734,7 +6798,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/hive-hivebuystuff/package.json
+++ b/hive-hivebuystuff/package.json
@@ -17,6 +17,7 @@
     "stripe": "^17.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/hive-hivebuystuff/playwright.config.ts
+++ b/hive-hivebuystuff/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    baseURL: process.env.BASE_URL ?? "https://hivebuystuff.hive.baby",
+    headless: true,
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+  reporter: [["list"], ["html", { open: "never" }]],
+});


### PR DESCRIPTION
## What's here

### E2E Playwright test suite (13 tests, 5 files)

| File | Tests |
|---|---|
| `health.spec.ts` | `/api/health` → `{status:ok, engine:HiveBuyStuff}` |
| `landing.spec.ts` | Hive logo, wordmark, 5 backends, tabs, footer, manifest `theme_color: #D4AF37`, FirstVisitCard dismiss + no-replay |
| `templates.spec.ts` | API CRUD, ownership enforcement (wrong user_id → 404), free tier 4th-list 429 |
| `cart.spec.ts` | AI routing for all 4 backends (walmart/target/amazon/instacart), usage counter increments |
| `settings.spec.ts` | Preferences round-trip, Settings UI tolerance options |

CI workflow: `.github/workflows/hivebuystuff-e2e.yml` — fires automatically after deploy workflow succeeds on main, plus `workflow_dispatch`. Results uploaded as artifact (7 days).

### V2 spec: `docs/hivebuystuff-v2-spec.md`

Full written plan for:
- **V2.1** — Magic key (portable identity, zero third-party, SHA-256 HMAC)
- **V2.2** — Chrome extension (Manifest V3, DOM automation, Honey model, $0/run)
- **V2.3** — Amazon PA-API affiliate links (3–8% commission)
- **V2.4** — Kroger OAuth2 + real cart API
- **V2.5** — Rolling 30-day usage window

## To merge

E2E workflow fires after deploy — merge this, then trigger a deploy (or wait for the next push to `hive-hivebuystuff/**`) to see the full E2E run in CI.

## Next: V2.1 magic key

Smallest next step with biggest user impact: portable identity so nothing is lost across devices. Ready to build immediately after this merges.

https://claude.ai/code/session_01Rui3Esi81w3XNrTkPpvjGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rui3Esi81w3XNrTkPpvjGL)_